### PR TITLE
Fix for [JENKINS-10225]

### DIFF
--- a/src/main/java/hudson/plugins/copyartifact/TriggeredBuildSelector.java
+++ b/src/main/java/hudson/plugins/copyartifact/TriggeredBuildSelector.java
@@ -37,9 +37,17 @@ import org.kohsuke.stapler.DataBoundConstructor;
  * @author Alan Harder
  */
 public class TriggeredBuildSelector extends BuildSelector {
+	private Boolean fallbackToLastSuccessful;
+		
     @DataBoundConstructor
-    public TriggeredBuildSelector() { }
+    public TriggeredBuildSelector(boolean fallback) {
+    	this.fallbackToLastSuccessful = fallback ? Boolean.TRUE : null;
+    }
 
+    public boolean isFallbackToLastSuccessful() {
+        return fallbackToLastSuccessful != null && fallbackToLastSuccessful.booleanValue();
+    }
+    
     @Override
     public Run<?,?> getBuild(Job<?,?> job, EnvVars env, BuildFilter filter, Run<?,?> parent) {
         String jobName = job.getFullName();
@@ -50,7 +58,16 @@ public class TriggeredBuildSelector extends BuildSelector {
                 return (run != null && filter.isSelectable(run, env)) ? run : null;
             }
         }
+        if(isFallbackToLastSuccessful()){
+        	//TODO: Write to console, that fallback is used.
+        	return super.getBuild(job, env, filter, parent);
+        }
         return null;
+    }
+    
+    @Override
+    protected boolean isSelectable(Run<?,?> run, EnvVars env) {
+        return isFallbackToLastSuccessful();
     }
 
     @Extension(ordinal=25)

--- a/src/main/resources/hudson/plugins/copyartifact/TriggeredBuildSelector/config.jelly
+++ b/src/main/resources/hudson/plugins/copyartifact/TriggeredBuildSelector/config.jelly
@@ -1,0 +1,30 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-2010, Sun Microsystems, Inc., Alan Harder
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+  <f:entry title="">
+    <f:checkbox name="fallback" checked="${selector.isFallbackToLastSuccessful()}"/>
+    <label class="attach-previous">${%Use "Last successful build" as fallback}</label>
+  </f:entry>
+</j:jelly>

--- a/src/test/java/hudson/plugins/copyartifact/CopyArtifactTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/CopyArtifactTest.java
@@ -489,7 +489,7 @@ public class CopyArtifactTest extends HudsonTestCase {
         FreeStyleProject other = createArtifactProject(),
         p = createFreeStyleProject();
         p.getBuildersList().add(new CopyArtifact(other.getName(),
-                                    new TriggeredBuildSelector(), "*.txt", "", false, false));
+                                    new TriggeredBuildSelector(false), "*.txt", "", false, false));
         other.getPublishersList().add(new BuildTrigger(p.getFullName(), false));
         hudson.rebuildDependencyGraph();
         assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()));
@@ -503,6 +503,11 @@ public class CopyArtifactTest extends HudsonTestCase {
         assertFile(false, "subdir/subfoo.txt", b);
         // Verify error if build not triggered by upstream job:
         assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0, new UserCause()).get());
+        // test fallback
+        p.getBuildersList().remove(CopyArtifact.class);
+        p.getBuildersList().add(new CopyArtifact(other.getName(),
+                new TriggeredBuildSelector(true), "*.txt", "", false, false));
+        assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0, new UserCause()).get());
     }
 
     public void testFlatten() throws Exception {


### PR DESCRIPTION
Fix for [JENKINS-10225] Use last successful build as fallback when
upstream triggered build is started on its own.
Added test for fallback.
