### PR TITLE
fix for https://issues.jenkins-ci.org/browse/JENKINS-11828

### DIFF
--- a/src/main/java/hudson/plugins/copyartifact/TriggeredBuildSelector.java
+++ b/src/main/java/hudson/plugins/copyartifact/TriggeredBuildSelector.java
@@ -27,11 +27,8 @@ import hudson.EnvVars;
 import hudson.Extension;
 import hudson.matrix.MatrixConfiguration;
 import hudson.matrix.MatrixRun;
-import hudson.model.Descriptor;
-import hudson.model.Cause;
+import hudson.model.*;
 import hudson.model.Cause.UpstreamCause;
-import hudson.model.Job;
-import hudson.model.Run;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -73,7 +70,7 @@ public class TriggeredBuildSelector extends BuildSelector {
     
     @Override
     protected boolean isSelectable(Run<?,?> run, EnvVars env) {
-        return isFallbackToLastSuccessful();
+        return isFallbackToLastSuccessful() && run.getResult().isBetterOrEqualTo(Result.SUCCESS);
     }
 
     @Extension(ordinal=25)


### PR DESCRIPTION
Using "Upstream build which triggered" with "Last successfull" fallback uses last build as fallback and not last successful. This patch fixes this behaviour.
