### PR TITLE
support hierarchical model

### DIFF
--- a/src/main/java/hudson/plugins/copyartifact/CopyArtifact.java
+++ b/src/main/java/hudson/plugins/copyartifact/CopyArtifact.java
@@ -37,14 +37,17 @@ import hudson.matrix.MatrixProject;
 import hudson.maven.MavenModuleSet;
 import hudson.maven.MavenModuleSetBuild;
 import hudson.model.AbstractBuild;
+import hudson.model.AbstractItem;
 import hudson.model.AbstractProject;
 import hudson.model.Build;
 import hudson.model.BuildListener;
 import hudson.model.Descriptor;
 import hudson.model.EnvironmentContributingAction;
 import hudson.model.Hudson;
-import hudson.model.Job;
 import hudson.model.Item;
+import hudson.model.ItemGroup;
+import hudson.model.Items;
+import hudson.model.Job;
 import hudson.model.Project;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -73,6 +76,7 @@ import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.Stapler;
 
 /**
  * Build step to copy artifacts from another project.
@@ -89,9 +93,12 @@ public class CopyArtifact extends Builder {
     @DataBoundConstructor
     public CopyArtifact(String projectName, BuildSelector selector, String filter, String target,
                         boolean flatten, boolean optional) {
+        ItemGroup context = Stapler.getCurrentRequest().findAncestorObject(ItemGroup.class);
+        if (context == null) context = Hudson.getInstance();
+
         // Prevents both invalid values and access to artifacts of projects which this user cannot see.
         // If value is parameterized, it will be checked when build runs.
-        if (projectName.indexOf('$') < 0 && new JobResolver(projectName).job == null)
+        if (projectName.indexOf('$') < 0 && new JobResolver(context, projectName).job == null)
             projectName = ""; // Ignore/clear bad value to avoid ugly 500 page
         this.projectName = projectName;
         this.selector = selector;
@@ -145,7 +152,7 @@ public class CopyArtifact extends Builder {
             EnvVars env = build.getEnvironment(listener);
             env.overrideAll(build.getBuildVariables()); // Add in matrix axes..
             expandedProject = env.expand(projectName);
-            JobResolver job = new JobResolver(expandedProject);
+            JobResolver job = new JobResolver(build.getProject().getParent(), expandedProject);
             if (job.job != null && !expandedProject.equals(projectName)
                 // If projectName is parameterized, need to do permission check on source project.
                 // Would like to check if user who started build has permission, but unable to get
@@ -246,20 +253,19 @@ public class CopyArtifact extends Builder {
         }
     }
 
-    // Find the job from the given name; usually just a Hudson.getItemByFullName lookup,
+    // Find the job from the given name inside the current itemGroup; usually just a getItem lookup by name,
     // but this class encapsulates additional logic like filtering on parameters.
     private static class JobResolver {
         Job<?,?> job;
         BuildFilter filter = new BuildFilter();
 
-        JobResolver(String projectName) {
-            Hudson hudson = Hudson.getInstance();
-            job = hudson.getItemByFullName(projectName, Job.class);
+        JobResolver(ItemGroup context, String projectName) {
+            job = fromName(context, projectName);
             if (job == null) {
                 // Check for parameterized job with filter (see help file)
                 int i = projectName.indexOf('/');
                 if (i > 0) {
-                    Job<?,?> candidate = hudson.getItemByFullName(projectName.substring(0, i), Job.class);
+                    Job<?,?> candidate = fromName(context, projectName.substring(0, i));
                     if (candidate != null) {
                         ParametersBuildFilter pFilter = new ParametersBuildFilter(projectName.substring(i + 1));
                         if (pFilter.isValid(candidate)) {
@@ -270,17 +276,24 @@ public class CopyArtifact extends Builder {
                 }
             }
         }
+
+    }
+
+    public static Job fromName(ItemGroup context, String projectName) {
+        List<Job> jobs = Items.fromNameList(context, projectName, Job.class);
+        if (jobs.isEmpty()) return null;
+        return jobs.get(0);
     }
 
     @Extension
     public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
 
         public FormValidation doCheckProjectName(
-                @AncestorInPath AccessControlled anc, @QueryParameter String value) {
+                @AncestorInPath AbstractItem anc, @QueryParameter String value) {
             // Require CONFIGURE permission on this project
             if (!anc.hasPermission(Item.CONFIGURE)) return FormValidation.ok();
             FormValidation result;
-            Item item = new JobResolver(value).job;
+            Item item = new JobResolver(anc.getParent(), value).job;
             if (item != null)
                 result = item instanceof MavenModuleSet
                        ? FormValidation.warning(Messages.CopyArtifact_MavenProject())

--- a/src/main/java/hudson/plugins/copyartifact/PermalinkBuildSelector.java
+++ b/src/main/java/hudson/plugins/copyartifact/PermalinkBuildSelector.java
@@ -37,6 +37,8 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
+import static hudson.plugins.copyartifact.CopyArtifact.fromName;
+
 /**
  * Picks up a build through {@link Permalink}
  *
@@ -68,7 +70,7 @@ public class PermalinkBuildSelector extends BuildSelector {
         public ListBoxModel doFillIdItems(@AncestorInPath Job defaultJob, @RelativePath("..") @QueryParameter("projectName") String projectName) {
             // gracefully fall back to some job, if none is given
             Job j = null;
-            if (projectName!=null)  j = Hudson.getInstance().getItemByFullName(projectName,Job.class);
+            if (projectName!=null)  j = fromName(defaultJob.getParent(), projectName);
             if (j==null)    j = defaultJob;
 
             ListBoxModel r = new ListBoxModel();


### PR DESCRIPTION
Jobs in jenkins are hosted by ItemGroups, that are not necessary Jenkins "root" instance
Cloudbees folder plugin is a sample plugin to use this feature to organize jobs as a nested structure, probably other plugin will as well

This change uses project ItemGroup as reference path when resolving projectName to Job, so that short name will be resoled from the same ItemGroup (folder), and relative path may be used to get jobs from other levels in the hierarchy
