### PR TITLE
JENKINS-12134 - Make fingerprinting artifacts optional.

### DIFF
--- a/src/main/java/hudson/plugins/copyartifact/Copier.java
+++ b/src/main/java/hudson/plugins/copyartifact/Copier.java
@@ -43,25 +43,43 @@ public abstract class Copier implements CopyMethod, ExtensionPoint {
     public void init(Run src, AbstractBuild<?,?> dst, FilePath srcDir, FilePath baseTargetDir) throws IOException, InterruptedException {
         init(srcDir,baseTargetDir); // for backward compatibility with older subtypes
     }
+
+    /**
+     * @deprecated 
+     *      call/override {@link #copyAll(FilePath srcDir, String filter, FilePath targetDir, boolean fingerprintArtifacts)} instead.
+     */
+    public int copyAll(FilePath srcDir, String filter, FilePath targetDir) throws IOException, InterruptedException {
+        return copyAll(srcDir, filter, targetDir, true);
+    }
     
     /**
      * Copy files matching the given file mask to the specified target.
      * @param srcDir Source directory
      * @param filter Ant GLOB pattern
      * @param targetDir Target directory
+     * @param fingerprintArtifacts boolean controlling if the copy should also fingerprint the artifacts
      * @return Number of files that were copied
      * @see FilePath#copyRecursiveTo(String,FilePath)
      */
-    public abstract int copyAll(FilePath srcDir, String filter, FilePath targetDir) throws IOException, InterruptedException;
+    public abstract int copyAll(FilePath srcDir, String filter, FilePath targetDir, boolean fingerprintArtifacts) throws IOException, InterruptedException;
+    
+    /**
+     * @deprecated 
+     *      call/override {@link #copyOne(FilePath source, FilePath target, boolean fingerprintArtifacts)} instead.
+     */
+    public void copyOne(FilePath source, FilePath target) throws IOException, InterruptedException {
+        copyOne(source, target, true);
+    }
 
     /**
      * Copy a single file.
      * @param source Source file
      * @param target Target file (includes filename; this is not the target directory).
      *   Directory for target should already exist (copy-artifact build step calls mkdirs).
+     * @param fingerprintArtifacts boolean controlling if the copy should also fingerprint the artifacts
      * @see FilePath#copyTo(FilePath)
      */
-    public abstract void copyOne(FilePath source, FilePath target) throws IOException, InterruptedException;
+    public abstract void copyOne(FilePath source, FilePath target, boolean fingerprintArtifacts) throws IOException, InterruptedException;
 
     /**
      * Ends what's started by the {@link #init(Run, AbstractBuild, FilePath, FilePath)} method.
@@ -94,11 +112,11 @@ public abstract class Copier implements CopyMethod, ExtensionPoint {
                 legacy.init(srcDir, baseTargetDir);
             }
 
-            public int copyAll(FilePath srcDir, String filter, FilePath targetDir) throws IOException, InterruptedException {
+            public int copyAll(FilePath srcDir, String filter, FilePath targetDir, boolean fingerprintArtifacts) throws IOException, InterruptedException {
                 return legacy.copyAll(srcDir, filter, targetDir);
             }
 
-            public void copyOne(FilePath source, FilePath target) throws IOException, InterruptedException {
+            public void copyOne(FilePath source, FilePath target, boolean fingerprintArtifacts) throws IOException, InterruptedException {
                 legacy.copyOne(source, target);
             }
 

--- a/src/main/java/hudson/plugins/copyartifact/CopyArtifact.java
+++ b/src/main/java/hudson/plugins/copyartifact/CopyArtifact.java
@@ -89,10 +89,11 @@ public class CopyArtifact extends Builder {
     private /*almost final*/ BuildSelector selector;
     @Deprecated private transient Boolean stable;
     private final Boolean flatten, optional;
+    private final Boolean fingerprintArtifacts;
 
     @DataBoundConstructor
     public CopyArtifact(String projectName, BuildSelector selector, String filter, String target,
-                        boolean flatten, boolean optional) {
+                        boolean flatten, boolean optional, boolean fingerprintArtifacts) {
         // check the permissions only if we can
         StaplerRequest req = Stapler.getCurrentRequest();
         if (req!=null) {
@@ -111,6 +112,7 @@ public class CopyArtifact extends Builder {
         this.target = Util.fixNull(target).trim();
         this.flatten = flatten ? Boolean.TRUE : null;
         this.optional = optional ? Boolean.TRUE : null;
+        this.fingerprintArtifacts = fingerprintArtifacts ? Boolean.TRUE : null;
     }
 
     // Upgrade data from old format
@@ -146,6 +148,10 @@ public class CopyArtifact extends Builder {
 
     public boolean isOptional() {
         return optional != null && optional;
+    }
+
+    public boolean isFingerprintArtifacts() {
+        return fingerprintArtifacts != null && fingerprintArtifacts;
     }
 
     @Override
@@ -240,12 +246,12 @@ public class CopyArtifact extends Builder {
         try {
             int cnt;
             if (!isFlatten())
-                cnt = copier.copyAll(srcDir, expandedFilter, targetDir);
+                cnt = copier.copyAll(srcDir, expandedFilter, targetDir, isFingerprintArtifacts());
             else {
                 targetDir.mkdirs();  // Create target if needed
                 FilePath[] list = srcDir.list(expandedFilter);
                 for (FilePath file : list)
-                    copier.copyOne(file, new FilePath(targetDir, file.getName()));
+                    copier.copyOne(file, new FilePath(targetDir, file.getName()), isFingerprintArtifacts());
                 cnt = list.length;
             }
 

--- a/src/main/java/hudson/plugins/copyartifact/FilePathCopyMethod.java
+++ b/src/main/java/hudson/plugins/copyartifact/FilePathCopyMethod.java
@@ -40,14 +40,14 @@ import java.io.IOException;
 public class FilePathCopyMethod extends Copier {
     /** @see FilePath#recursiveCopyTo(String,FilePath) */
     @Override
-    public int copyAll(FilePath srcDir, String filter, FilePath targetDir)
+    public int copyAll(FilePath srcDir, String filter, FilePath targetDir, boolean fingerprintArtifacts)
             throws IOException, InterruptedException {
         return srcDir.copyRecursiveTo(filter, targetDir);
     }
 
     /** @see FilePath#copyTo(FilePath) */
     @Override
-    public void copyOne(FilePath source, FilePath target)
+    public void copyOne(FilePath source, FilePath target, boolean fingerprintArtifacts)
             throws IOException, InterruptedException {
         source.copyToWithPermission(target);
     }

--- a/src/main/resources/hudson/plugins/copyartifact/CopyArtifact/config.jelly
+++ b/src/main/resources/hudson/plugins/copyartifact/CopyArtifact/config.jelly
@@ -40,5 +40,8 @@ THE SOFTWARE.
     <st:nbsp/> <st:nbsp/> <st:nbsp/> <st:nbsp/> <st:nbsp/>
     <f:checkbox field="optional"/>
     <label class="attach-previous">${%Optional}</label>
+    <st:nbsp/> <st:nbsp/> <st:nbsp/> <st:nbsp/> <st:nbsp/>
+    <f:checkbox field="fingerprintArtifacts"/>
+    <label class="attach-previous">${%Fingerprint Artifacts}</label>
   </f:entry>
 </j:jelly>

--- a/src/main/webapp/help-flatten-optional.html
+++ b/src/main/webapp/help-flatten-optional.html
@@ -8,4 +8,7 @@
   matching the "Which build" condition selected above, the build's workspace does
   not exist or is inaccessible, or no artifacts are found matching the specified
   pattern.  By default this build step fails the build if no artifacts are copied.
+  <p/>
+  Select "Fingerprint Artifacts" to automatically fingerprint all artifacts
+  that are copied as part of this build step.
 </div>

--- a/src/test/java/hudson/plugins/copyartifact/CopyArtifactTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/CopyArtifactTest.java
@@ -79,11 +79,11 @@ import org.jvnet.hudson.test.recipes.LocalData;
 public class CopyArtifactTest extends HudsonTestCase {
 
     private FreeStyleProject createProject(String otherProject, String filter,
-            String target, boolean stable, boolean flatten, boolean optional)
+            String target, boolean stable, boolean flatten, boolean optional, boolean fingerprintArtifacts)
             throws IOException {
         FreeStyleProject p = createFreeStyleProject();
         p.getBuildersList().add(new CopyArtifact(otherProject,
-                new StatusBuildSelector(stable), filter, target, flatten, optional));
+                new StatusBuildSelector(stable), filter, target, flatten, optional, fingerprintArtifacts));
         return p;
     }
 
@@ -131,19 +131,19 @@ public class CopyArtifactTest extends HudsonTestCase {
     }
 
     public void testMissingProject() throws Exception {
-        FreeStyleProject p = createProject("invalid", "", "", false, false, false);
+        FreeStyleProject p = createProject("invalid", "", "", false, false, false, true);
         assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0, new UserCause()).get());
     }
 
     public void testMissingBuild() throws Exception {
         FreeStyleProject other = createFreeStyleProject(),
-                         p = createProject(other.getName(), "", "", false, false, false);
+                         p = createProject(other.getName(), "", "", false, false, false, true);
         assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0, new UserCause()).get());
     }
 
     public void testMissingStableBuild() throws Exception {
         FreeStyleProject other = createFreeStyleProject(),
-                         p = createProject(other.getName(), "", "", true, false, false);
+                         p = createProject(other.getName(), "", "", true, false, false, true);
         // Make an unstable build in "other"
         other.getBuildersList().add(new UnstableBuilder());
         assertBuildStatus(Result.UNSTABLE, other.scheduleBuild2(0, new UserCause()).get());
@@ -152,14 +152,14 @@ public class CopyArtifactTest extends HudsonTestCase {
 
     public void testMissingArtifact() throws Exception {
         FreeStyleProject other = createFreeStyleProject(),
-                         p = createProject(other.getName(), "*.txt", "", false, false, false);
+                         p = createProject(other.getName(), "*.txt", "", false, false, false, true);
         assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0, new UserCause()).get());
     }
 
-    public void testCopyAll() throws Exception {
+    public void testCopyAllWithFingerprints() throws Exception {
         FreeStyleProject other = createArtifactProject(),
-                         p = createProject(other.getName(), "", "", false, false, false);
+                         p = createProject(other.getName(), "", "", false, false, false, true);
         FreeStyleBuild s = assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
         assertBuildStatusSuccess(b);
@@ -174,10 +174,25 @@ public class CopyArtifactTest extends HudsonTestCase {
         assertTrue(f.getRangeSet(p).includes(b.getNumber()));
     }
 
+    public void testCopyAllWithoutFingerprints() throws Exception {
+        FreeStyleProject other = createArtifactProject(),
+                         p = createProject(other.getName(), "", "", false, false, false, false);
+        FreeStyleBuild s = assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
+        FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
+        assertBuildStatusSuccess(b);
+        assertFile(true, "foo.txt", b);
+        assertFile(true, "subdir/subfoo.txt", b);
+        assertFile(true, "deepfoo/a/b/c.log", b);
+        
+        // testing no fingerprints
+        String d = b.getWorkspace().child("foo.txt").digest();
+        assertNull(Hudson.getInstance().getFingerprintMap().get(d));
+    }
+
     public void testCopyWithFilter() throws Exception {
         FreeStyleProject other = createArtifactProject(),
                  p = createProject(other.getName(), "**/bogus*, **/sub*, bogus/**", "",
-                                   false, false, false);
+                                   false, false, false, true);
         assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
         assertBuildStatusSuccess(b);
@@ -189,7 +204,7 @@ public class CopyArtifactTest extends HudsonTestCase {
     public void testCopyToTarget() throws Exception {
         FreeStyleProject other = createArtifactProject(),
                  p = createProject(other.getName(), "deep*/**", "new/deep/dir",
-                                   true, false, false);
+                                   true, false, false, true);
         assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
         assertBuildStatusSuccess(b);
@@ -205,7 +220,7 @@ public class CopyArtifactTest extends HudsonTestCase {
         if(c.isOffline())
             fail("Slave failed to go online: " + c.getLog());
         FreeStyleProject other = createArtifactProject(),
-                         p = createProject(other.getName(), "", "", false, false, false);
+                         p = createProject(other.getName(), "", "", false, false, false, true);
         assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         p.setAssignedLabel(node.getSelfLabel());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
@@ -219,7 +234,7 @@ public class CopyArtifactTest extends HudsonTestCase {
     public void testParameters() throws Exception {
         FreeStyleProject other = createArtifactProject(),
                          p = createProject("$PROJSRC", "$BASE/*.txt", "$TARGET/bar",
-                                           false, false, false);
+                                           false, false, false, true);
         assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause(),
                 new ParametersAction(new StringParameterValue("PROJSRC", other.getName()),
@@ -234,7 +249,7 @@ public class CopyArtifactTest extends HudsonTestCase {
     public void testMatrixJob() throws Exception {
         MatrixProject other = createMatrixArtifactProject();
         FreeStyleProject p = createProject(other.getName() + "/FOO=two", "", "",
-                                           true, false, false);
+                                           true, false, false, true);
         assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
         assertBuildStatusSuccess(b);
@@ -250,7 +265,7 @@ public class CopyArtifactTest extends HudsonTestCase {
                       p = createMatrixProject();
         p.setAxes(new AxisList(new Axis("FOO", "one", "two"))); // should match other job
         p.getBuildersList().add(new CopyArtifact(other.getName() + "/FOO=$FOO",
-                                    new StatusBuildSelector(true), "", "", false, false));
+                                    new StatusBuildSelector(true), "", "", false, false, true));
         assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         MatrixBuild b = p.scheduleBuild2(0, new UserCause()).get();
         assertBuildStatusSuccess(b);
@@ -285,7 +300,7 @@ public class CopyArtifactTest extends HudsonTestCase {
         mp.getBuildersList().add(new ArchMatrixBuilder());
         mp.getPublishersList().add(new ArtifactArchiver("target/*", "", false));
         assertBuildStatusSuccess(mp.scheduleBuild2(0, new UserCause()).get());
-        FreeStyleProject p = createProject(mp.getName(), "", "", true, false, false);
+        FreeStyleProject p = createProject(mp.getName(), "", "", true, false, false, true);
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
         assertBuildStatusSuccess(b);
         assertFile(true, "ARCH=sparc/target/readme.txt", b);
@@ -315,7 +330,7 @@ public class CopyArtifactTest extends HudsonTestCase {
         MavenModuleSet mp = setupMavenJob();
         assertBuildStatusSuccess(mp.scheduleBuild2(0, new UserCause()).get());
         FreeStyleProject p = createProject(mp.getName() + "/org.jvnet.hudson.main.test.multimod$moduleB",
-                                           "", "", true, false, false);
+                                           "", "", true, false, false, true);
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
         String dir = "org.jvnet.hudson.main.test.multimod/";
         assertFile(true, dir + "moduleB/1.0-SNAPSHOT/moduleB-1.0-SNAPSHOT.jar", b);
@@ -326,7 +341,7 @@ public class CopyArtifactTest extends HudsonTestCase {
     public void testMavenAll() throws Exception {
         MavenModuleSet mp = setupMavenJob();
         assertBuildStatusSuccess(mp.scheduleBuild2(0, new UserCause()).get());
-        FreeStyleProject p = createProject(mp.getName(), "", "", true, false, false);
+        FreeStyleProject p = createProject(mp.getName(), "", "", true, false, false, true);
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
         String dir = "org.jvnet.hudson.main.test.multimod/";
         assertFile(true, dir + "moduleA/1.0-SNAPSHOT/moduleA-1.0-SNAPSHOT.jar", b);
@@ -336,7 +351,7 @@ public class CopyArtifactTest extends HudsonTestCase {
         assertFile(true, dir + "moduleC/1.0-SNAPSHOT/moduleC-1.0-SNAPSHOT.jar", b);
         assertFile(true, dir + pomName("moduleC", "1.0-SNAPSHOT"), b);
         // Test with filter
-        p = createProject(mp.getName(), "**/*.jar", "", true, false, false);
+        p = createProject(mp.getName(), "**/*.jar", "", true, false, false, true);
         b = p.scheduleBuild2(0, new UserCause()).get();
         assertFile(true, dir + "moduleA/1.0-SNAPSHOT/moduleA-1.0-SNAPSHOT.jar", b);
         assertFile(false, dir + pomName("moduleA", "1.0-SNAPSHOT"), b);
@@ -354,7 +369,7 @@ public class CopyArtifactTest extends HudsonTestCase {
         mp.setIsArchivingDisabled(true);
         mp.getPublishersList().add(new ArtifactArchiver("moduleB/*.xml", "", false));
         assertBuildStatusSuccess(mp.scheduleBuild2(0, new UserCause()).get());
-        FreeStyleProject p = createProject(mp.getName(), "", "", true, false, false);
+        FreeStyleProject p = createProject(mp.getName(), "", "", true, false, false, true);
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
         // Archived artifact should be copied:
         assertFile(true, "moduleB/pom.xml", b);
@@ -372,7 +387,7 @@ public class CopyArtifactTest extends HudsonTestCase {
     public void testCopyFromWorkspace() throws Exception {
         FreeStyleProject other = createFreeStyleProject(), p = createFreeStyleProject();
         p.getBuildersList().add(new CopyArtifact(other.getName(), new WorkspaceSelector(),
-                                "**/*.txt", "", true, false));
+                                "**/*.txt", "", true, false, true));
         // Run a build that places a file in the workspace, but does not archive anything
         other.getBuildersList().add(new ArtifactBuilder());
         assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
@@ -386,7 +401,7 @@ public class CopyArtifactTest extends HudsonTestCase {
     /** projectName in CopyArtifact build steps should be updated if a job is renamed */
     public void testJobRename() throws Exception {
         FreeStyleProject other = createFreeStyleProject(),
-                         p = createProject(other.getName(), "", "", true, false, false);
+                         p = createProject(other.getName(), "", "", true, false, false, true);
         assertEquals("before", other.getName(),
                      ((CopyArtifact)p.getBuilders().get(0)).getProjectName());
         String newName = other.getName() + "-new";
@@ -398,7 +413,7 @@ public class CopyArtifactTest extends HudsonTestCase {
         MatrixProject otherm = createMatrixProject(),
                       mp = createMatrixProject();
         mp.getBuildersList().add(new CopyArtifact(otherm.getName() + "/FOO=$FOO",
-                                     new SavedBuildSelector(), "", "", false, false));
+                                     new SavedBuildSelector(), "", "", false, false, true));
         assertEquals("before", otherm.getName() + "/FOO=$FOO",
                      ((CopyArtifact)mp.getBuilders().get(0)).getProjectName());
         otherm.renameTo(newName = otherm.getName() + "-new");
@@ -410,7 +425,7 @@ public class CopyArtifactTest extends HudsonTestCase {
         FreeStyleProject other = createArtifactProject(),
                          p = createFreeStyleProject();
         p.getBuildersList().add(new CopyArtifact(other.getName(),
-                                    new SavedBuildSelector(), "*.txt", "", false, false));
+                                    new SavedBuildSelector(), "*.txt", "", false, false, true));
         FreeStyleBuild b = other.scheduleBuild2(0, new UserCause(),
                 new ParametersAction(new StringParameterValue("FOO", "buildone"))).get();
         assertBuildStatusSuccess(b);
@@ -428,7 +443,7 @@ public class CopyArtifactTest extends HudsonTestCase {
                          p = createFreeStyleProject();
         SpecificBuildSelector sbs = new SpecificBuildSelector("1");
         assertEquals("1", sbs.getBuildNumber());
-        p.getBuildersList().add(new CopyArtifact(other.getName(), sbs, "*.txt", "", false, false));
+        p.getBuildersList().add(new CopyArtifact(other.getName(), sbs, "*.txt", "", false, false, true));
         assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause(),
                 new ParametersAction(new StringParameterValue("FOO", "buildone"))).get());
         assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()));
@@ -443,7 +458,7 @@ public class CopyArtifactTest extends HudsonTestCase {
         FreeStyleProject other = createArtifactProject(),
                          p = createFreeStyleProject();
         p.getBuildersList().add(new CopyArtifact(other.getName(),
-                                    new SpecificBuildSelector("$BAR"), "*.txt", "", false, false));
+                                    new SpecificBuildSelector("$BAR"), "*.txt", "", false, false, true));
         assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause(),
                 new ParametersAction(new StringParameterValue("FOO", "buildone"))).get());
         assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()));
@@ -460,7 +475,7 @@ public class CopyArtifactTest extends HudsonTestCase {
                          p = createFreeStyleProject();
         ParameterizedBuildSelector pbs = new ParameterizedBuildSelector("PBS");
         assertEquals("PBS", pbs.getParameterName());
-        p.getBuildersList().add(new CopyArtifact(other.getName(), pbs, "*.txt", "", false, false));
+        p.getBuildersList().add(new CopyArtifact(other.getName(), pbs, "*.txt", "", false, false, true));
         FreeStyleBuild b = other.scheduleBuild2(0, new UserCause(),
                 new ParametersAction(new StringParameterValue("FOO", "buildone"))).get();
         assertBuildStatusSuccess(b);
@@ -478,7 +493,7 @@ public class CopyArtifactTest extends HudsonTestCase {
         FreeStyleProject other = createArtifactProject(),
                          p = createFreeStyleProject();
         p.getBuildersList().add(new CopyArtifact(other.getName(),
-                                    new PermalinkBuildSelector("lastStableBuild"), "*.txt", "", false, false));
+                                    new PermalinkBuildSelector("lastStableBuild"), "*.txt", "", false, false, true));
         FreeStyleBuild b = other.scheduleBuild2(0, new UserCause(),
                 new ParametersAction(new StringParameterValue("FOO", "buildone"))).get();
         assertBuildStatusSuccess(b);
@@ -491,7 +506,7 @@ public class CopyArtifactTest extends HudsonTestCase {
         assertFile(false, "subdir/subfoo.txt", b);
         // Invalid permalink
         p.getBuildersList().replace(new CopyArtifact(other.getName(),
-                new PermalinkBuildSelector("fooBuild"), "*.txt", "", false, false));
+                new PermalinkBuildSelector("fooBuild"), "*.txt", "", false, false, true));
         assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0, new UserCause()).get());
     }
 
@@ -499,7 +514,7 @@ public class CopyArtifactTest extends HudsonTestCase {
         FreeStyleProject other = createArtifactProject(),
                          p = createFreeStyleProject();
         p.getBuildersList().add(new CopyArtifact(other.getName(),
-                                    new TriggeredBuildSelector(false), "*.txt", "", false, false));
+                                    new TriggeredBuildSelector(false), "*.txt", "", false, false, true));
         other.getPublishersList().add(new BuildTrigger(p.getFullName(), false));
         hudson.rebuildDependencyGraph();
         assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()));
@@ -522,7 +537,7 @@ public class CopyArtifactTest extends HudsonTestCase {
         
         p.getBuildersList().remove(CopyArtifact.class);
         p.getBuildersList().add(new CopyArtifact(other.getName(),
-                new TriggeredBuildSelector(true), "*.txt", "", false, false));
+                new TriggeredBuildSelector(true), "*.txt", "", false, false, true));
         assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0, new UserCause()).get());
     }
 
@@ -534,7 +549,7 @@ public class CopyArtifactTest extends HudsonTestCase {
         MatrixProject other = createMatrixArtifactProject();
         FreeStyleProject p = createFreeStyleProject();
         p.getBuildersList().add(new CopyArtifact(other.getName() + "/FOO=two",
-                                    new TriggeredBuildSelector(false), "*.txt", "", false, false));
+                                    new TriggeredBuildSelector(false), "*.txt", "", false, false, true));
         other.getPublishersList().add(new BuildTrigger(p.getFullName(), false));
         hudson.rebuildDependencyGraph();
         assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
@@ -557,7 +572,7 @@ public class CopyArtifactTest extends HudsonTestCase {
         MatrixProject p = createMatrixProject();
         p.setAxes(new AxisList(new Axis("FOO", "one", "two")));
         p.getBuildersList().add(new CopyArtifact(other.getName(),
-                                    new TriggeredBuildSelector(false), "*.txt", "", false, false));
+                                    new TriggeredBuildSelector(false), "*.txt", "", false, false, true));
         other.getPublishersList().add(new BuildTrigger(p.getFullName(), false));
         hudson.rebuildDependencyGraph();
         assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
@@ -573,7 +588,7 @@ public class CopyArtifactTest extends HudsonTestCase {
 
     public void testFlatten() throws Exception {
         FreeStyleProject other = createArtifactProject(),
-                         p = createProject(other.getName(), "", "newdir", false, true, false);
+                         p = createProject(other.getName(), "", "newdir", false, true, false, true);
         assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
         assertBuildStatusSuccess(b);
@@ -584,19 +599,19 @@ public class CopyArtifactTest extends HudsonTestCase {
 
     public void testOptional_MissingProject() throws Exception {
         // Missing project still fails even when copy is optional
-        FreeStyleProject p = createProject("invalid", "", "", false, false, true);
+        FreeStyleProject p = createProject("invalid", "", "", false, false, true, true);
         assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0, new UserCause()).get());
     }
 
     public void testOptional_MissingBuild() throws Exception {
         FreeStyleProject other = createFreeStyleProject(),
-                         p = createProject(other.getName(), "", "", false, false, true);
+                         p = createProject(other.getName(), "", "", false, false, true, true);
         assertBuildStatusSuccess(p.scheduleBuild2(0, new UserCause()).get());
     }
 
     public void testOptional_MissingArtifact() throws Exception {
         FreeStyleProject other = createFreeStyleProject(),
-                         p = createProject(other.getName(), "*.txt", "", false, false, true);
+                         p = createProject(other.getName(), "*.txt", "", false, false, true, true);
         assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         assertBuildStatusSuccess(p.scheduleBuild2(0, new UserCause()).get());
     }
@@ -611,7 +626,7 @@ public class CopyArtifactTest extends HudsonTestCase {
             public Object call() throws Exception {
                 assertNull("Job should not be accessible to anonymous", hudson.getItem("testJob"));
                 assertEquals("Should ignore/clear value for inaccessible project", "",
-                        new CopyArtifact("testJob", null, null, null, false, false).getProjectName());
+                        new CopyArtifact("testJob", null, null, null, false, false, true).getProjectName());
                 return null;
             }
         });
@@ -622,7 +637,7 @@ public class CopyArtifactTest extends HudsonTestCase {
         wc.executeOnServer(new Callable<Object>() {
             public Object call() throws Exception {
                 assertEquals("Should allow use of testJob for joe", "testJob",
-                             new CopyArtifact("testJob", null, null, null, false, false).getProjectName());
+                             new CopyArtifact("testJob", null, null, null, false, false, true).getProjectName());
                 return null;
             }
         });
@@ -635,7 +650,7 @@ public class CopyArtifactTest extends HudsonTestCase {
      */
     @LocalData
     public void testPermissionWhenParameterized() throws Exception {
-        FreeStyleProject p = createProject("test$JOB", "", "", false, false, false);
+        FreeStyleProject p = createProject("test$JOB", "", "", false, false, false, true);
         // Build step should succeed when this parameter expands to a job accessible
         // to authenticated users (even if triggered by anonymous, as in this case):
         SecurityContextHolder.clearContext();
@@ -658,7 +673,7 @@ public class CopyArtifactTest extends HudsonTestCase {
         // This test fails before Jenkins 1.406
         if (new VersionNumber("1.406").isNewerThan(Hudson.getVersion())) return; // Skip
 
-        FreeStyleProject p = createProject("testMatrix/FOO=$FOO", "", "", false, false, false);
+        FreeStyleProject p = createProject("testMatrix/FOO=$FOO", "", "", false, false, false, true);
         // Build step should succeed when this parameter expands to a job accessible to
         // authenticated users, even when selecting a single matrix config, not the parent job:
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause(),
@@ -677,7 +692,7 @@ public class CopyArtifactTest extends HudsonTestCase {
                 Collections.singletonMap(Item.READ, Collections.singleton("authenticated"))));
         assertBuildStatusSuccess(mp.scheduleBuild2(0, new UserCause()).get());
         FreeStyleProject p = createProject(mp.getName() + "/org.jvnet.hudson.main.test.multimod$FOO",
-                                           "", "", false, false, false);
+                                           "", "", false, false, false, true);
         // Build step should succeed when this parameter expands to a job accessible to
         // authenticated users, even when selecting a single maven module, not the parent job:
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause(),
@@ -696,7 +711,7 @@ public class CopyArtifactTest extends HudsonTestCase {
     public void testEnvData() throws Exception {
         // Also test conversion of job name to env var name, only keeping letters:
         FreeStyleProject other = createArtifactProject("My (Test) Job"),
-                 p = createProject(other.getName(), "", "", false, false, false);
+                 p = createProject(other.getName(), "", "", false, false, false, true);
         CaptureEnvironmentBuilder envStep = new CaptureEnvironmentBuilder();
         p.getBuildersList().add(envStep);
         // Bump up the build number a bit:
@@ -732,37 +747,37 @@ public class CopyArtifactTest extends HudsonTestCase {
                 new BooleanParameterValue("BAR", true),
                 new StringParameterValue("BAZ", "bar"))).get());
 
-        FreeStyleProject p = createProject(other.getName() + "/FOO=bar", "*.txt", "", true, false, false);
+        FreeStyleProject p = createProject(other.getName() + "/FOO=bar", "*.txt", "", true, false, false, true);
         CaptureEnvironmentBuilder envStep = new CaptureEnvironmentBuilder();
         p.getBuildersList().add(envStep);
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
         assertBuildStatusSuccess(b);
         assertEquals("2", envStep.getEnvVars().get("COPYARTIFACT_BUILD_NUMBER_FOO_JOB"));
 
-        p = createProject(other.getName() + "/BAR=false", "*.txt", "", true, false, false);
+        p = createProject(other.getName() + "/BAR=false", "*.txt", "", true, false, false, true);
         p.getBuildersList().add(envStep);
         b = p.scheduleBuild2(0, new UserCause()).get();
         assertBuildStatusSuccess(b);
         assertEquals("1", envStep.getEnvVars().get("COPYARTIFACT_BUILD_NUMBER_FOO_JOB"));
 
-        p = createProject(other.getName() + "/BAZ=foo,BAR=true", "*.txt", "", true, false, false);
+        p = createProject(other.getName() + "/BAZ=foo,BAR=true", "*.txt", "", true, false, false, true);
         p.getBuildersList().add(envStep);
         b = p.scheduleBuild2(0, new UserCause()).get();
         assertBuildStatusSuccess(b);
         assertEquals("2", envStep.getEnvVars().get("COPYARTIFACT_BUILD_NUMBER_FOO_JOB"));
 
-        p = createProject(other.getName() + "/FOO=foo,BAR=false,BAZ=baz", "*.txt", "", true, false, false);
+        p = createProject(other.getName() + "/FOO=foo,BAR=false,BAZ=baz", "*.txt", "", true, false, false, true);
         p.getBuildersList().add(envStep);
         b = p.scheduleBuild2(0, new UserCause()).get();
         assertBuildStatusSuccess(b);
         assertEquals("1", envStep.getEnvVars().get("COPYARTIFACT_BUILD_NUMBER_FOO_JOB"));
 
-        p = createProject(other.getName() + "/BAZ=bar,FOO=bogus", "*.txt", "", true, false, false);
+        p = createProject(other.getName() + "/BAZ=bar,FOO=bogus", "*.txt", "", true, false, false, true);
         b = p.scheduleBuild2(0, new UserCause()).get();
         assertBuildStatus(Result.FAILURE, b);
 
         // Test matching other build variables besides parameters
-        p = createProject(other.getName() + "/BUILD_NUMBER=2", "*.txt", "", true, false, false);
+        p = createProject(other.getName() + "/BUILD_NUMBER=2", "*.txt", "", true, false, false, true);
         p.getBuildersList().add(envStep);
         b = p.scheduleBuild2(0, new UserCause()).get();
         assertBuildStatusSuccess(b);
@@ -790,7 +805,7 @@ public class CopyArtifactTest extends HudsonTestCase {
         assertBuildStatusSuccess(b);
         b.keepLog(true);
         p.getBuildersList().add(new CopyArtifact(other.getName() + "/FOO=buildone",
-                                    new SavedBuildSelector(), "*.txt", "", false, false));
+                                    new SavedBuildSelector(), "*.txt", "", false, false, true));
         assertBuildStatusSuccess(b = other.scheduleBuild2(0, new UserCause()).get());
         b.keepLog(true); // Keep #2 too, but it doesn't have FOO=buildone so should not be selected
         assertBuildStatusSuccess(b = p.scheduleBuild2(0, new UserCause()).get());
@@ -805,7 +820,7 @@ public class CopyArtifactTest extends HudsonTestCase {
                          p = createFreeStyleProject();
         other.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("FOO", "")));
         p.getBuildersList().add(new CopyArtifact(other.getName() + "/FOO=bogus",
-                                    new SpecificBuildSelector("1"), "*.txt", "", false, false));
+                                    new SpecificBuildSelector("1"), "*.txt", "", false, false, true));
         assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause(),
                 new ParametersAction(new StringParameterValue("FOO", "foo"))).get());
         assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()));
@@ -822,14 +837,14 @@ public class CopyArtifactTest extends HudsonTestCase {
     // Test field getters
     public void testFields() throws Exception {
         FreeStyleProject p = createFreeStyleProject();
-        CopyArtifact ca = new CopyArtifact(p.getFullName(), new SavedBuildSelector(), "filter", "target", false, true);
+        CopyArtifact ca = new CopyArtifact(p.getFullName(), new SavedBuildSelector(), "filter", "target", false, true, true);
         assertEquals(p.getFullName(), ca.getProjectName());
         assertSame(SavedBuildSelector.class, ca.getBuildSelector().getClass());
         assertEquals("filter", ca.getFilter());
         assertEquals("target", ca.getTarget());
         assertFalse(ca.isFlatten());
         assertTrue(ca.isOptional());
-        ca = new CopyArtifact("foo", null, null, null, true, false);
+        ca = new CopyArtifact("foo", null, null, null, true, false, true);
         assertTrue(ca.isFlatten());
         assertFalse(ca.isOptional());
     }


### PR DESCRIPTION
I'd like to propose this change which introduces a checkbox to the copy artifact build step that allows the user to select whether or not the artifacts for the build step should be fingerprinted, rather than just always being fingerprinted.
