### PR TITLE
[Fixed JENKINS-16847] Added explicit support for copy-artifact steps being part of MultiJob pi...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,12 @@
         <artifactId>maven-plugin</artifactId>
         <optional>true</optional>
       </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>jenkins-multijob-plugin</artifactId>
+            <version>1.7</version>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <reporting>

--- a/src/main/java/hudson/plugins/copyartifact/TriggeredBuildSelector.java
+++ b/src/main/java/hudson/plugins/copyartifact/TriggeredBuildSelector.java
@@ -23,20 +23,21 @@
  */
 package hudson.plugins.copyartifact;
 
+import com.tikal.jenkins.plugins.multijob.MultiJobBuild;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.matrix.MatrixConfiguration;
 import hudson.matrix.MatrixRun;
-import hudson.model.Result;
-import hudson.model.Descriptor;
-import hudson.model.Cause;
+import hudson.model.*;
 import hudson.model.Cause.UpstreamCause;
-import hudson.model.Job;
-import hudson.model.Run;
 import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Copy artifacts from the build that triggered this build.
+ *
  * @author Alan Harder
  */
 public class TriggeredBuildSelector extends BuildSelector {
@@ -50,35 +51,77 @@ public class TriggeredBuildSelector extends BuildSelector {
     public boolean isFallbackToLastSuccessful() {
         return fallbackToLastSuccessful != null && fallbackToLastSuccessful.booleanValue();
     }
-    
+
     @Override
-    public Run<?,?> getBuild(Job<?,?> job, EnvVars env, BuildFilter filter, Run<?,?> parent) {
+    public Run<?, ?> getBuild(Job<?, ?> job, EnvVars env, BuildFilter filter, Run<?, ?> parent) {
         // Upstream job for matrix will be parent project, not individual configuration:
         String jobName = job instanceof MatrixConfiguration
-            ? job.getParent().getFullName() : job.getFullName();
-        // Matrix run is triggered by its parent project, so check causes of parent build:
-        for (Cause cause : parent instanceof MatrixRun
-                ? ((MatrixRun)parent).getParentBuild().getCauses() : parent.getCauses()) {
-            if (cause instanceof UpstreamCause
-                    && jobName.equals(((UpstreamCause)cause).getUpstreamProject())) {
-                Run<?,?> run = job.getBuildByNumber(((UpstreamCause)cause).getUpstreamBuild());
-                return (run != null && filter.isSelectable(run, env)) ? run : null;
+                ? job.getParent().getFullName() : job.getFullName();
+        List<Cause> causes = new ArrayList<Cause>();
+
+        if (parent instanceof MatrixRun) {
+            causes.addAll(((MatrixRun) parent).getParentBuild().getCauses());
+        } else {
+            causes.addAll(parent.getCauses());
+        }
+
+        for (Cause cause : causes) {
+            if (cause instanceof UpstreamCause) {
+
+                UpstreamCause upstreamCause = (UpstreamCause) cause;
+                Job upstreamJob = Hudson.getInstance().getItemByFullName(upstreamCause.getUpstreamProject(), Job.class);
+
+                Run upstreamRun = upstreamJob.getBuildByNumber(upstreamCause.getUpstreamBuild());
+
+                Run matchingUpstreamProjectInPipeline = findMatchingUpstreamProjectInPipeline(upstreamRun, jobName);
+
+                if (matchingUpstreamProjectInPipeline != null && filter.isSelectable(matchingUpstreamProjectInPipeline, env)) {
+                    return matchingUpstreamProjectInPipeline;
+                }
             }
         }
+
         if (isFallbackToLastSuccessful()) {
-            //TODO: Write to console, that fallback is used.
             return super.getBuild(job, env, filter, parent);
         }
         return null;
     }
-    
+
+    private Run findMatchingUpstreamProjectInPipeline(Run upstreamRun, String jobName) {
+        if (upstreamRun==null) {
+            return null;
+        }
+
+        if (upstreamRun instanceof MultiJobBuild) {
+
+            MultiJobBuild mjb = (MultiJobBuild) upstreamRun;
+            List<MultiJobBuild.SubBuild> subBuilds = mjb.getSubBuilds();
+            List<AbstractProject> downstreamProjects = mjb.getProject().getDownstreamProjects();
+
+            for (AbstractProject downstreamProject : downstreamProjects) {
+                for (MultiJobBuild.SubBuild subBuild : subBuilds) {
+                        if (subBuild.getJobName().equalsIgnoreCase(downstreamProject.getName())) {
+                            Run currentRun = findMatchingUpstreamProjectInPipeline(downstreamProject.getBuildByNumber(subBuild.getBuildNumber()), jobName);
+                            if (currentRun!=null) {
+                                return currentRun;
+                            }
+                        }
+                }
+            }
+        } else if (upstreamRun.getParent().getName().equalsIgnoreCase(jobName) && upstreamRun.getResult()!=null) {
+            return upstreamRun;
+        }
+
+        return null;
+    }
+
     @Override
-    protected boolean isSelectable(Run<?,?> run, EnvVars env) {
+    protected boolean isSelectable(Run<?, ?> run, EnvVars env) {
         return isFallbackToLastSuccessful() && run.getResult().isBetterOrEqualTo(Result.SUCCESS);
     }
 
-    @Extension(ordinal=25)
+    @Extension(ordinal = 25)
     public static final Descriptor<BuildSelector> DESCRIPTOR =
             new SimpleBuildSelectorDescriptor(
-                TriggeredBuildSelector.class, Messages._TriggeredBuildSelector_DisplayName());
+                    TriggeredBuildSelector.class, Messages._TriggeredBuildSelector_DisplayName());
 }


### PR DESCRIPTION
...pelines, to detect other builds finished as part of the same multijob build as "upstream".
This allows using "Upstream project that triggered this build" for artifact selection and making sure it copies the artifact from the right build (before the only solution was "last successful build", for longer pipelines unacceptable as several builds could happen "in between".

A recursive algorithm will descend also to parent builds being multijobs themselves.
It is yet to be tested if this also will work "up" the chain (https://github.com/jenkinsci/copyartifact-plugin/pull/15 suggests not, while mu understanding of of getCauses() contract suggest it will - to be tested).
