### PR TITLE
Support standard Run parameters to select build instead of only custom ParameterizedBuildSelector

### DIFF
--- a/src/main/java/hudson/plugins/copyartifact/ParameterizedBuildSelector.java
+++ b/src/main/java/hudson/plugins/copyartifact/ParameterizedBuildSelector.java
@@ -25,9 +25,13 @@ package hudson.plugins.copyartifact;
 
 import hudson.EnvVars;
 import hudson.Extension;
+import hudson.model.ParameterValue;
 import hudson.model.Descriptor;
 import hudson.model.Job;
+import hudson.model.ParametersAction;
 import hudson.model.Run;
+import hudson.model.RunParameterValue;
+
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -49,8 +53,25 @@ public class ParameterizedBuildSelector extends BuildSelector {
 
     @Override
     public Run<?,?> getBuild(Job<?,?> job, EnvVars env, BuildFilter filter, Run<?,?> parent) {
-        return BuildSelectorParameter.getSelectorFromXml(env.get(parameterName))
-                                     .getBuild(job, env, filter, parent);
+    	Run<?,?> run = checkForRunParameter(parent);
+    	
+    	if (run == null) {
+    		run = BuildSelectorParameter.getSelectorFromXml(env.get(parameterName))
+                    .getBuild(job, env, filter, parent);
+    	}
+    	
+    	return run;
+    }
+    
+    public Run<?,?> checkForRunParameter(Run<?,?> parent) {
+    	ParametersAction parameters = parent.getAction(ParametersAction.class);
+    	ParameterValue parameterValue = parameters.getParameter(parameterName);
+    	
+    	if (parameterValue instanceof RunParameterValue) {
+    		return ((RunParameterValue) parameterValue).getRun();
+    	} else {
+    		return null;
+    	}
     }
 
     @Extension(ordinal=-20)


### PR DESCRIPTION
I had a use case where I wanted to use a standard run parameter as part of my job as well as the copy artifacts plugin.  The copy artifacts plugin requires that you use the custom parameterized build selector so I would end up defining the parameter twice.  This pull request adds support in the Copy artifacts plugin to look for standard Jenkins Run parameter and uses that if found, otherwise it continues with the current behavior.