### PR TITLE
EnvAction to support hierarchical jobs (cloudbees folders)

### DIFF
--- a/src/main/java/hudson/plugins/copyartifact/CopyArtifact.java
+++ b/src/main/java/hudson/plugins/copyartifact/CopyArtifact.java
@@ -396,8 +396,13 @@ public class CopyArtifact extends Builder {
 
         private Job getProject(ItemGroup ctx, String projectName) {
             String[] parts = projectName.split("/");
+            if (projectName.startsWith("/")) ctx = Jenkins.getInstance();
             for (String part : parts) {
-                if (part == null) continue;
+                if (part.length() == 0) continue;
+                if (part.equals("..")) {
+                    ctx = ((Item) ctx).getParent();
+                    continue;
+                }
                 Item i = ctx.getItem(part);
                 if (i instanceof Job) return (Job) i;
                 ctx = (ItemGroup) i;


### PR DESCRIPTION
projectname can include "/" from a folder
so need to disambiguate FOO/BAR, that can be either a "BAR" module for maven job "FOO", or a "BAR" job for "FOO" folder

This change check each nested "/" level until a Job is found, and use it to generate the env variable name.
