### PR TITLE
manage relative job name when considering renamed items

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.466</version>
+        <version>1.475</version>
     </parent>
 
     <artifactId>copyartifact</artifactId>


### PR DESCRIPTION
Use Items.computeRelativeNamesAfterRenaming (introduced in 1.475) to detect renamed jobs and update copyartifact configuration
