### PR TITLE
Specific Build Selector fixes

### DIFF
--- a/src/main/resources/hudson/plugins/copyartifact/SpecificBuildSelector/config.jelly
+++ b/src/main/resources/hudson/plugins/copyartifact/SpecificBuildSelector/config.jelly
@@ -23,16 +23,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
-  <f:entry title="${%Build number}">
-    <f:textbox clazz="required pos-num-or-param" name="buildNumber"
-               value="${selector.buildNumber}"/>
-    <st:once>
-      <script type="text/javascript"><![CDATA[ Behaviour.register({
-        "INPUT.pos-num-or-param": function(e) {
-          registerRegexpValidator(e,/^(\d*[1-9]\d*|\$$\w+|)$$/,
-            '${h.jsStringEscape('%Not a positive number or build parameter')}');
-        }});
-      ]]></script>
-    </st:once>
+  <f:entry title="${%Build number}" help="/plugin/copyartifact/help-specificBuild.html">
+    <f:textbox name="buildNumber" value="${selector.buildNumber}"/>
   </f:entry>
 </j:jelly>

--- a/src/main/webapp/help-specificBuild.html
+++ b/src/main/webapp/help-specificBuild.html
@@ -1,0 +1,6 @@
+<div>
+  While this selector is for build numbers (e.g. "22" for build #22),
+  you can also resolve build parameters or environment variables (e.g. "${PARAM}").
+  The display name of a build and permalinks (e.g. "lastSuccessfulBuild", "lastBuild"...)
+  can be used as well.
+</div>

--- a/src/test/java/hudson/plugins/copyartifact/SpecificBuildSelectorTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/SpecificBuildSelectorTest.java
@@ -20,4 +20,34 @@ public class SpecificBuildSelectorTest extends HudsonTestCase {
         assertEquals(null, s.getBuild(p, new EnvVars("HUM", "two"), f, null));
     }
 
+    @Bug(19693)
+    public void testDisplayName() throws Exception {
+        FreeStyleProject p = createFreeStyleProject();
+        assertBuildStatusSuccess(p.scheduleBuild2(0));
+        assertBuildStatusSuccess(p.scheduleBuild2(0));
+        assertBuildStatusSuccess(p.scheduleBuild2(0));
+        assertEquals(3, p.getLastBuild().number);
+        p.getBuildByNumber(2).setDisplayName("RC1");
+        BuildSelector s = new SpecificBuildSelector("$NUM");
+        BuildFilter f = new BuildFilter();
+        assertEquals(p.getBuildByNumber(2), s.getBuild(p, new EnvVars("NUM", "RC1"), f, null));
+        assertEquals(null, s.getBuild(p, new EnvVars("NUM", "RC2"), f, null));
+    }
+
+    public void testPermalink() throws Exception {
+        FreeStyleProject p = createFreeStyleProject();
+        assertBuildStatusSuccess(p.scheduleBuild2(0));
+        assertBuildStatusSuccess(p.scheduleBuild2(0));
+        assertBuildStatusSuccess(p.scheduleBuild2(0));
+        assertEquals(3, p.getLastBuild().number);
+        BuildSelector s = new SpecificBuildSelector("$NUM");
+        BuildFilter f = new BuildFilter();
+        assertEquals(p.getLastSuccessfulBuild(), s.getBuild(p, new EnvVars("NUM", "lastSuccessfulBuild"), f, null));
+        assertEquals(p.getLastStableBuild(), s.getBuild(p, new EnvVars("NUM", "lastStableBuild"), f, null));
+        assertEquals(p.getLastBuild(), s.getBuild(p, new EnvVars("NUM", "lastBuild"), f, null));
+        assertEquals(p.getLastFailedBuild(), s.getBuild(p, new EnvVars("NUM", "lastFailedBuild"), f, null));
+        assertEquals(p.getLastUnstableBuild(), s.getBuild(p, new EnvVars("NUM", "lastUnstableBuild"), f, null));
+        assertEquals(p.getLastUnsuccessfulBuild(), s.getBuild(p, new EnvVars("NUM", "lastUnsuccessfulBuild"), f, null));
+    }
+
 }


### PR DESCRIPTION
Aside from fixing [JENKINS-19693](https://issues.jenkins-ci.org/browse/JENKINS-19693), the specific build will also allow to use permalinks (e.g. lastSuccessfulBuild).

If you take the example of a build pipeline, trigerring job after job and want to reuse the same artifact in multiple jobs of that pipeline, you can use a variable in the specific build field which turns out to be a build parameter (String). The value is provided by the job that triggers the build and fill it with the build number of another job so that the same artifact can be reused. However, when a job alone is triggered and not as part of a build pipeline or build flow, it is convenient to be able to use a permalink like lastSuccessfulBuild as the default value for that build parameter.
