### PR TITLE
Fingerprint only if any fingerprints already exist.

### DIFF
--- a/src/main/java/hudson/plugins/copyartifact/FingerprintingCopyMethod.java
+++ b/src/main/java/hudson/plugins/copyartifact/FingerprintingCopyMethod.java
@@ -95,12 +95,15 @@ public class FingerprintingCopyMethod extends Copier {
 
             FingerprintMap map = Jenkins.getInstance().getFingerprintMap();
 
-            Fingerprint f = map.getOrCreate(src, s.getName(), digest);
-            if (src!=null) {
-                f.add((AbstractBuild)src);
+            if (map.isReady()) {
+                // only create fingerprints if some exist already
+                Fingerprint f = map.getOrCreate(src, s.getName(), digest);
+                if (src!=null) {
+                    f.add((AbstractBuild)src);
+                }
+                f.add(dst);
+                fingerprints.put(s.getName(), digest);
             }
-            f.add(dst);
-            fingerprints.put(s.getName(), digest);
         } catch (IOException e) {
             throw new IOException2("Failed to copy "+s+" to "+d,e);
         }


### PR DESCRIPTION
In Jenkins installations that don't use fingerprints (with the express
goal to not offer e.g. fingerprint-related sidepanel items), it makes
no sense for the Copy Artifact plugin to introduce them.

This change only creates fingerprints in the FingerprintingCopyMethod if
any fingerprints already exist in the Jenkins installation, otherwise,
no fingerprints are created.
