### PR TITLE
RFC: Record copied artifacts in build action

### DIFF
--- a/src/main/java/hudson/plugins/copyartifact/CopiedArtifactsRunAction.java
+++ b/src/main/java/hudson/plugins/copyartifact/CopiedArtifactsRunAction.java
@@ -1,0 +1,107 @@
+package hudson.plugins.copyartifact;
+
+import hudson.model.Action;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.FilePath;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.ArrayList;
+import java.io.Serializable;
+
+import org.kohsuke.stapler.StaplerProxy;
+
+public class CopiedArtifactsRunAction implements Action, StaplerProxy {
+
+    static {
+        Run.XSTREAM2.alias("copied-artifact", CopySource.class);
+    }
+
+    private Collection<CopySource> copiedArtifacts;
+
+    public static class CopySource {
+        private String jobname;
+        private int buildNumber;
+        private Set<String> files;
+
+        public CopySource(String jobname, int buildNumber) {
+            this.jobname = jobname;
+            this.buildNumber = buildNumber;
+            this.files = new HashSet<String>();
+        }
+
+        public void addSourceFile(String file) {
+            this.files.add(file);
+        }
+
+        public String getSourceJobName() {
+            return jobname;
+        }
+
+        public int getSourceBuildNumber() {
+            return buildNumber;
+        }
+
+        public Collection<String> getFiles() {
+            return this.files;
+        }
+    }
+
+    public Object getTarget() {
+        return this;
+    }
+
+    public CopiedArtifactsRunAction() {
+        this.copiedArtifacts = new ArrayList<CopySource>();
+    }
+
+    public String getIconFileName() {
+        return "package.png";
+    }
+
+    public String getDisplayName() {
+        return "Copied Artifacts";
+    }
+
+    public String getUrlName() {
+        return "copiedArtifacts";
+    }
+
+    public Collection<CopySource> getCopiedArtifacts() {
+        ArrayList<CopySource> result = new ArrayList<CopySource>(this.copiedArtifacts);
+        Collections.sort(result, new Comparator<CopySource>() {
+            public int compare(CopySource one, CopySource two) {
+                if (!one.getSourceJobName().equals(two.getSourceJobName())) {
+                    return one.getSourceJobName().compareTo(two.getSourceJobName());
+                }
+                return Integer.valueOf(one.getSourceBuildNumber()).compareTo(Integer.valueOf(two.getSourceBuildNumber()));
+            }
+        });
+        return result;
+    }
+
+    public void recordSourceFile(Run src, String file) {
+        Job job = src.getParent();
+        int buildNumber = src.getNumber();
+
+        CopySource cs = null;
+
+        for (CopySource cs2: this.copiedArtifacts) {
+            if (cs2.getSourceJobName().equals(job.getFullName()) && cs2.getSourceBuildNumber() == buildNumber) {
+                cs = cs2;
+                break;
+            }
+        }
+
+        if (cs == null) {
+            cs = new CopySource(job.getFullName(), buildNumber);
+            this.copiedArtifacts.add(cs);
+        }
+
+        cs.addSourceFile(file);
+    }
+}

--- a/src/main/java/hudson/plugins/copyartifact/CopyArtifact.java
+++ b/src/main/java/hudson/plugins/copyartifact/CopyArtifact.java
@@ -519,6 +519,11 @@ public class CopyArtifact extends Builder implements SimpleBuildStep {
             return isOptional();  // Fail build unless copy is optional
         }
 
+        CopiedArtifactsRunAction a = dst.getAction(CopiedArtifactsRunAction.class);
+        if (a == null) {
+            a = new CopiedArtifactsRunAction();
+            dst.addAction(a);
+        }
         copier.initialize(src, dst, srcDir, baseTargetDir);
         try {
             int cnt;
@@ -527,8 +532,11 @@ public class CopyArtifact extends Builder implements SimpleBuildStep {
             else {
                 targetDir.mkdirs();  // Create target if needed
                 FilePath[] list = srcDir.list(expandedFilter, expandedExcludes, false);
-                for (FilePath file : list)
+                for (FilePath file : list) {
                     copier.copyOne(file, new FilePath(targetDir, file.getName()), isFingerprintArtifacts());
+                    String relativePath = file.getRemote().substring(srcDir.getRemote().length() + 1);
+                    a.recordSourceFile(src, relativePath);
+                }
                 cnt = list.length;
             }
 

--- a/src/main/java/hudson/plugins/copyartifact/FingerprintingCopyMethod.java
+++ b/src/main/java/hudson/plugins/copyartifact/FingerprintingCopyMethod.java
@@ -38,6 +38,9 @@ public class FingerprintingCopyMethod extends Copier {
     private static final Logger LOGGER = Logger.getLogger(FingerprintingCopyMethod.class.getName());
     private Run<?,?> src;
     private Run<?,?> dst;
+
+    private CopiedArtifactsRunAction cara;
+
     private final MessageDigest md5 = newMD5();
     private final Map<String,String> fingerprints = new HashMap<String, String>();
 
@@ -45,6 +48,7 @@ public class FingerprintingCopyMethod extends Copier {
     public void initialize(Run<?, ?> src, Run<?, ?> dst, FilePath srcDir, FilePath baseTargetDir) throws IOException, InterruptedException {
         this.src = src;
         this.dst = dst;
+        this.cara = dst.getAction(CopiedArtifactsRunAction.class);
         fingerprints.clear();
     }
 
@@ -65,6 +69,9 @@ public class FingerprintingCopyMethod extends Copier {
             if (tail.startsWith("\\") || tail.startsWith("/"))
                 tail = tail.substring(1);
             copyOne(file, new FilePath(targetDir, tail), fingerprintArtifacts);
+            if (this.cara != null) {
+                this.cara.recordSourceFile(this.src, tail);
+            }
         }
         return list.length;
     }

--- a/src/main/resources/hudson/plugins/copyartifact/CopiedArtifactsRunAction/index.jelly
+++ b/src/main/resources/hudson/plugins/copyartifact/CopiedArtifactsRunAction/index.jelly
@@ -1,0 +1,43 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+  <l:layout title="${%Copied Artifacts}" norefresh="true">
+    <j:invokeStatic var="currentThread" className="java.lang.Thread" method="currentThread"/>
+    <j:invoke var="buildClass" on="${currentThread.contextClassLoader}" method="loadClass">
+        <j:arg value="hudson.model.AbstractBuild"/>
+    </j:invoke>
+    <j:set var="build" value="${request.findAncestorObject(buildClass)}"/>
+    <st:include page="sidepanel.jelly" it="${build}" />
+    <l:main-panel>
+      <h1>${%Copied Artifacts}</h1>
+      <p>${%This build copied artifacts from the following other builds:}</p>
+      
+      <j:forEach var="source" items="${it.copiedArtifacts}">
+        <h3 id="${source.sourceJobName}-${source.sourceBuildNumber}">
+          <j:set var="job" value="${app.getItemByFullName(source.sourceJobName)}"/>
+          <j:choose>
+            <j:when test="${job!=null}">
+              <a href="${rootURL}/${job.url}" class="model-link inside">${job.fullDisplayName}</a>
+            </j:when>
+            <j:otherwise>
+              ${source.sourceJobName}
+            </j:otherwise>
+          </j:choose>
+          <j:set var="run" value="${job.getBuildByNumber(source.sourceBuildNumber)}"/>
+          <j:choose>
+            <j:when test="${run!=null}">
+              <st:nbsp/><a href="${rootURL}/${run.url}" class="model-link inside">#${source.sourceBuildNumber}</a>
+            </j:when>
+            <j:otherwise>
+              <st:nbsp/>#${source.sourceBuildNumber}
+            </j:otherwise>
+          </j:choose>
+        </h3>
+        <p>Copied ${source.files.size()} file(s):</p>
+        <ul>
+          <j:forEach var="f" items="${source.files}">
+            <li>${f}</li>
+          </j:forEach>
+        </ul>
+      </j:forEach>
+    </l:main-panel>
+  </l:layout>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/copyartifact/CopiedArtifactsRunAction/summary.jelly
+++ b/src/main/resources/hudson/plugins/copyartifact/CopiedArtifactsRunAction/summary.jelly
@@ -1,0 +1,31 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+  <t:summary icon="package.png">
+    <p>${%This build copied artifacts from the following other builds:}</p>
+    <ul>
+      <j:forEach var="source" items="${it.copiedArtifacts}">
+        <li>
+          <a href="copiedArtifacts/#${source.sourceJobName}-${source.sourceBuildNumber}">${source.files.size()} file(s)</a> from
+          <j:set var="job" value="${app.getItemByFullName(source.sourceJobName)}"/>
+          <j:choose>
+            <j:when test="${job!=null}">
+              <a href="${rootURL}/${job.url}" class="model-link inside">${job.fullDisplayName}</a>
+            </j:when>
+            <j:otherwise>
+              ${source.sourceJobName}
+            </j:otherwise>
+          </j:choose>
+          <j:set var="run" value="${job.getBuildByNumber(source.sourceBuildNumber)}"/>
+          <j:choose>
+            <j:when test="${run!=null}">
+              <st:nbsp/><a href="${rootURL}/${run.url}" class="model-link inside">#${source.sourceBuildNumber}</a>
+            </j:when>
+            <j:otherwise>
+              <st:nbsp/>#${source.sourceBuildNumber}
+            </j:otherwise>
+          </j:choose>
+        </li>
+      </j:forEach>
+    </ul>
+  </t:summary>
+</j:jelly>


### PR DESCRIPTION
Which artifacts are copied in a certain build is as important as knowing the exact SCM revisions it is based on. So it should be displayed as prominently.
- Show list of source projects and builds on build page
- Add new sidepanel entry with detail page listing copied files

Screenshots below.

---

This is a request for comments on this implementation and shouldn't be merged yet. Is this complete? I'm not using matrix or Maven projects, so I'm really interested in information on those.

(Work in progress: weird difference needed to cover both flattened and unflattened copying; unknown whether `Run.XSTREAM2` is the right place to define aliases; insane approach to getting the current build's `sidepanel.jelly`; no full localizability; no tests; not making sure anchor names are valid)

---

![screen shot 2014-02-20 at 01 07 20](https://f.cloud.github.com/assets/1831569/2213635/27a7a440-99c3-11e3-9fbd-bdd566145c15.png)

---

![screen shot 2014-02-20 at 01 08 01](https://f.cloud.github.com/assets/1831569/2213636/27a7c77c-99c3-11e3-9f5b-f8bb3c609602.png)
