### PR TITLE
[FIXED JENKINS-22828] Expect an AbstractProject for input validation.

### DIFF
--- a/src/main/java/hudson/plugins/copyartifact/CopyArtifact.java
+++ b/src/main/java/hudson/plugins/copyartifact/CopyArtifact.java
@@ -387,7 +387,7 @@ public class CopyArtifact extends Builder {
     public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
 
         public FormValidation doCheckProjectName(
-                @AncestorInPath AbstractItem anc, @QueryParameter String value) {
+                @AncestorInPath AbstractProject anc, @QueryParameter String value) {
             // Require CONFIGURE permission on this project
             if (!anc.hasPermission(Item.CONFIGURE)) return FormValidation.ok();
             FormValidation result;


### PR DESCRIPTION
Input validation leads to wrong validation in case of a Cloudbees Templates plugin/Cloudbees Folders plugin combination, because the `getParent()` of the `@AncestorInPath AbstractItem` doesn't have to be the current `AbstractProject`'s `getParent()`.
### Steps to reproduce
1. Create a folder `/F`
2. Create a freestyle job `/F/fs`
3. Create a job template `/templ` with an _Heterogeneous components from descriptor_ attribute, use `hudson.tasks.Builder` as class. Use `/F/fs` as base for the Groovy transformation, but don't add any code (unnecessary).
4. Create a job based on `/templ` named `/F/templ-inst`.
5. Add a Copy Artifact build step. Enter `fs` as (relative) source project path.
### Expected results

Valid input.
### Actual results

> No such project 'fs'. Did you mean 'fs'?
### Notes

Using `AbstractProject` since that's used a few lines down for finding the recommendation.
