### PR TITLE
Fixing JENKINS-16847 MultiJob Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,12 @@
         <version>4.0</version>
         <scope>test</scope>
       </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>jenkins-multijob-plugin</artifactId>
+            <version>1.13</version>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/hudson/plugins/copyartifact/MultiJobBuildSelector.java
+++ b/src/main/java/hudson/plugins/copyartifact/MultiJobBuildSelector.java
@@ -1,0 +1,71 @@
+package hudson.plugins.copyartifact;
+
+import java.util.logging.Logger;
+
+import jenkins.model.Jenkins;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.model.Cause;
+import hudson.model.Cause.UpstreamCause;
+import hudson.model.Descriptor;
+import hudson.model.Job;
+import hudson.model.Run;
+
+import com.tikal.jenkins.plugins.multijob.MultiJobBuild;
+
+/**
+ * Copy artifacts from the build that was part of this MultiJob build.
+ * @author Ray Sennewald
+ */
+public class MultiJobBuildSelector extends BuildSelector {
+    private static final Logger LOGGER = Logger.getLogger(MultiJobBuildSelector.class.getName());
+
+    @DataBoundConstructor
+    public MultiJobBuildSelector() { }
+
+    @Override
+    public Run<?, ?> getBuild(Job<?, ?> job, EnvVars env, BuildFilter filter, Run<?, ?> parent) {
+        MultiJobBuild multiJobBuild = null;
+        // Are we in the MultiJob itself and trying to get an artifact from a Phase Build?
+        if (parent instanceof MultiJobBuild) {
+            multiJobBuild = (MultiJobBuild)parent;
+        }
+        // Nope, look for Upstream MultiJob that triggered this run (Are we in a Phase job?)
+        else {
+            for (Cause cause : parent.getCauses()) {
+                UpstreamCause upstreamCause = (UpstreamCause)cause;
+                Job upstreamJob = Jenkins.getInstance().getItemByFullName(upstreamCause.getUpstreamProject(), Job.class);
+                Run upstreamRun = upstreamJob.getBuildByNumber(upstreamCause.getUpstreamBuild());
+
+                if (upstreamRun != null && upstreamRun instanceof MultiJobBuild) {
+                    multiJobBuild = (MultiJobBuild)upstreamRun;
+                }
+            }
+        }
+        if (multiJobBuild == null) {
+            LOGGER.warning(String.format("'%s' is not found to be part of a MultiJob Project.", parent.getFullDisplayName()));
+            return null;
+        }
+        // Get the run for our source Job in the current MultiJob Project's Build
+        for (MultiJobBuild.SubBuild subBuild : multiJobBuild.getSubBuilds()) {
+            // Find Job's specific build we want
+            if (subBuild.getJobName().equals(job.getFullDisplayName())) {
+                return job.getBuildByNumber(subBuild.getBuildNumber());
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public boolean isSelectable(Run<?,?> run, EnvVars env) {
+        return true;
+    }
+
+    @Extension(ordinal=20)
+    public static final Descriptor<BuildSelector> DESCRIPTOR =
+            new SimpleBuildSelectorDescriptor(
+                    MultiJobBuildSelector.class, Messages._MultiJobBuildSelector_DisplayName());
+}

--- a/src/main/resources/hudson/plugins/copyartifact/Messages.properties
+++ b/src/main/resources/hudson/plugins/copyartifact/Messages.properties
@@ -29,3 +29,4 @@ DownstreamBuildSelector.UpstreamProjectName.Required=Required
 DownstreamBuildSelector.UpstreamProjectName.NotFound=Not Found
 DownstreamBuildSelector.UpstreamBuildNumber.Required=Required
 DownstreamBuildSelector.UpstreamBuildNumber.NotFound=Not Found
+MultiJobBuildSelector.DisplayName=Build triggered by current MultiJob build

--- a/src/main/resources/hudson/plugins/copyartifact/MultiJobBuildSelector/config.jelly
+++ b/src/main/resources/hudson/plugins/copyartifact/MultiJobBuildSelector/config.jelly
@@ -1,0 +1,27 @@
+<!--
+The MIT License
+
+Copyright (c) 2014, Ray Sennewald
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+    <f:entry title="${%Usage Note}" help="/plugin/copyartifact/help-multijob.html" />
+</j:jelly>

--- a/src/main/webapp/help-multijob.html
+++ b/src/main/webapp/help-multijob.html
@@ -1,0 +1,5 @@
+<div>
+    Note that copying from a build that was triggered by the current MultiJob
+    build only works if the destination is a MultiJob or a Phase Job of a
+    MultiJob and the source is a Phase Job of the same MultiJob.
+</div>

--- a/src/test/java/hudson/plugins/copyartifact/MultiJobBuildSelectorTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/MultiJobBuildSelectorTest.java
@@ -1,0 +1,194 @@
+package hudson.plugins.copyartifact;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import hudson.FilePath;
+import hudson.model.Cause.UserCause;
+import hudson.model.FreeStyleProject;
+import hudson.model.FreeStyleBuild;
+import hudson.model.Result;
+import hudson.plugins.copyartifact.testutils.FileWriteBuilder;
+import hudson.tasks.ArtifactArchiver;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import com.tikal.jenkins.plugins.multijob.MultiJobBuild;
+import com.tikal.jenkins.plugins.multijob.MultiJobBuilder;
+import com.tikal.jenkins.plugins.multijob.MultiJobBuilder.ContinuationCondition;
+import com.tikal.jenkins.plugins.multijob.MultiJobProject;
+import com.tikal.jenkins.plugins.multijob.PhaseJobsConfig;
+import com.tikal.jenkins.plugins.multijob.PhaseJobsConfig.KillPhaseOnJobResultCondition;
+
+/**
+ * Test interaction of MultiJobBuildSelector with Jenkins Core & MultiJob Plugin.
+ * @author Ray Sennewald
+ */
+public class MultiJobBuildSelectorTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void testConfiguration() throws Exception {
+        FreeStyleProject p = j.createFreeStyleProject();
+
+        p.getBuildersList().add(
+                new CopyArtifact(
+                        "${PROJECT}",
+                        "",
+                        new MultiJobBuildSelector(),
+                        "**/*",
+                        "",
+                        "",
+                        false,
+                        false,
+                        true
+                )
+        );
+
+        p.save();
+
+        // Test that configuration persists when we load page.
+        j.submit(j.createWebClient().getPage(p, "configure").getFormByName("config"));
+
+        p = j.jenkins.getItemByFullName(p.getFullName(), FreeStyleProject.class);
+        assertNotNull(p);
+
+        CopyArtifact ca = p.getBuildersList().get(CopyArtifact.class);
+        assertNotNull(ca);
+
+        assertEquals(MultiJobBuildSelector.class, ca.getBuildSelector().getClass());
+    }
+
+    private FreeStyleProject setupArtifactSourcePhaseJob(String name) throws Exception {
+        FreeStyleProject phaseJob = j.jenkins.createProject(FreeStyleProject.class, name);
+        phaseJob.getBuildersList().add(new FileWriteBuilder("artifact.txt", "${BUILD_ID}"));
+        phaseJob.getPublishersList().add(new ArtifactArchiver(
+                "artifact.txt",
+                "",
+                false,
+                false
+        ));
+        phaseJob.save();
+        return phaseJob;
+    }
+
+    @Test
+    public void testCopyFromPhaseJobToMultiJob() throws Exception {
+        // Create Phase Job
+        FreeStyleProject phaseJob = setupArtifactSourcePhaseJob("phaseJob");
+        // Create MultiJob
+        // multiJobProject
+        //  |_ phase
+        //      |_ phaseJob
+        //
+        MultiJobProject multiJobProject = j.jenkins.createProject(MultiJobProject.class, "multi");
+        multiJobProject.setConcurrentBuild(true);
+        // Create Phase containing Job named 'phaseJob'
+        PhaseJobsConfig phase = new PhaseJobsConfig("phaseJob", null, true, null, KillPhaseOnJobResultCondition.NEVER, false);
+        List<PhaseJobsConfig> configTopList = new ArrayList<PhaseJobsConfig>();
+        configTopList.add(phase);
+        MultiJobBuilder phaseBuilder = new MultiJobBuilder("Phase", configTopList, ContinuationCondition.SUCCESSFUL);
+        multiJobProject.getBuildersList().add(phaseBuilder);
+        // Copy Artifact from 'phaseJob'
+        MultiJobBuildSelector mjbSelector = new MultiJobBuildSelector();
+        multiJobProject.getBuildersList().add(new CopyArtifact(
+                phaseJob.getFullName(),
+                "",
+                mjbSelector,
+                "**/*",
+                "",
+                "",
+                false,
+                false,
+                true
+        ));
+        multiJobProject.save();
+        // Trigger MultiJob
+        MultiJobBuild b = multiJobProject.scheduleBuild2(0, new UserCause()).get();
+        j.waitUntilNoActivity();
+        // Assert it did what we wanted
+        j.assertBuildStatus(Result.SUCCESS, b);
+        FilePath artifact = b.getWorkspace().child("artifact.txt");
+        assertTrue(artifact.exists());
+        assertEquals(phaseJob.getLastBuild().getId(), artifact.readToString());
+        // Ensure that the phaseJobBuild which occurred in the MultiJobBuild above is no longer the
+        //  lastBuild if we trigger a new independent build for phaseJob1
+        FreeStyleBuild expectedPhaseBuild = phaseJob.getLastBuild();
+        FreeStyleBuild lastBuild = phaseJob.scheduleBuild2(0, new UserCause()).get();
+        j.waitUntilNoActivity();
+        j.assertBuildStatus(Result.SUCCESS, lastBuild);
+        assertNotEquals(expectedPhaseBuild, lastBuild);
+        // Ensure that if we call getBuild on the mjbSelector it still returns the build
+        // that was part of the current MultiJobBuild and not the latest Build we just triggered.
+        FreeStyleBuild returnedPhaseBuild = (FreeStyleBuild)mjbSelector.getBuild(phaseJob, null, null, b);
+        assertEquals(returnedPhaseBuild, expectedPhaseBuild);
+    }
+
+    @Test
+    public void testCopyFromPhaseJobToPhaseJob() throws Exception {
+        // Create MultiJob
+        // multiJobProject
+        //  |_ phase 1
+        //      |_ phaseJob1
+        //  |_ phase 2
+        //      |_ phaseJob2
+        //
+        MultiJobProject multiJobProject = j.jenkins.createProject(MultiJobProject.class, "multi");
+        // Create PhaseJob1
+        FreeStyleProject phaseJob1 = setupArtifactSourcePhaseJob("phaseJob1");
+        // Create Phase1 containing Job named 'phaseJob1'
+        PhaseJobsConfig phase1 = new PhaseJobsConfig("phaseJob1", null, true, null, KillPhaseOnJobResultCondition.NEVER, false);
+        List<PhaseJobsConfig> configTopList = new ArrayList<PhaseJobsConfig>();
+        configTopList.add(phase1);
+        MultiJobBuilder phaseBuilder1 = new MultiJobBuilder("Phase1", configTopList, ContinuationCondition.SUCCESSFUL);
+        multiJobProject.getBuildersList().add(phaseBuilder1);
+        // Create PhaseJob2
+        FreeStyleProject phaseJob2 = j.jenkins.createProject(FreeStyleProject.class, "phaseJob2");
+        // Copy Artifact from 'phaseJob1'
+        MultiJobBuildSelector mjbSelector = new MultiJobBuildSelector();
+        phaseJob2.getBuildersList().add(new CopyArtifact(
+                phaseJob1.getFullName(),
+                "",
+                mjbSelector,
+                "**/*",
+                "",
+                "",
+                false,
+                false,
+                true
+        ));
+        phaseJob2.save();
+        // Create Phase2 containing Job named 'phaseJob2'
+        PhaseJobsConfig phase2 = new PhaseJobsConfig("phaseJob2", null, true, null, KillPhaseOnJobResultCondition.NEVER, false);
+        List<PhaseJobsConfig> configTopList2 = new ArrayList<PhaseJobsConfig>();
+        configTopList.add(phase2);
+        MultiJobBuilder phaseBuilder2 = new MultiJobBuilder("Phase2", configTopList2, ContinuationCondition.SUCCESSFUL);
+        multiJobProject.getBuildersList().add(phaseBuilder2);
+        multiJobProject.save();
+        // Trigger MultiJob
+        multiJobProject.scheduleBuild2(0, new UserCause()).get();
+        FreeStyleBuild b = phaseJob2.getLastBuild();
+        j.waitUntilNoActivity();
+        // Assert it did what we wanted
+        j.assertBuildStatus(Result.SUCCESS, b);
+        FilePath artifact = b.getWorkspace().child("artifact.txt");
+        assertTrue(artifact.exists());
+        assertEquals(phaseJob1.getLastBuild().getId(), artifact.readToString());
+        // Ensure that the phaseJobBuild1 which occurred in the MultiJobBuild above is no longer the
+        //  lastBuild if we trigger a new independent build for phaseJob1
+        FreeStyleBuild expectedPhaseBuild = phaseJob1.getLastBuild();
+        FreeStyleBuild lastBuild = phaseJob1.scheduleBuild2(0, new UserCause()).get();
+        j.waitUntilNoActivity();
+        j.assertBuildStatus(Result.SUCCESS, lastBuild);
+        assertNotEquals(expectedPhaseBuild, lastBuild);
+        // Ensure that if we call getBuild on the mjbSelector it still returns the build
+        // that was part of the current MultiJobBuild and not the latest Build we just triggered.
+        FreeStyleBuild returnedPhaseBuild = (FreeStyleBuild)mjbSelector.getBuild(phaseJob1, null, null, b);
+        assertEquals(returnedPhaseBuild, expectedPhaseBuild);
+    }
+}


### PR DESCRIPTION
-Added a new Build Selector called MultiJobBuildSelector.
-If selected, this will make the Copy Artifact Plugin look
for an artifact from that job's build which was part of the
current MultiJobBuild.
-This selector will work properly if you configure it with
a MultiJobProject which has a PhaseJob that archives an
artifact that you want to retrieve as part of the MultiJob.
-This selector will also work if you configure it to Copy an
Artifact from another Phase Job which was part of the
current MultiJob Build.
-Added tests to ensure this functionality works as expected.
-Adds MultiJob Plugin as a dependency.
