### PR TITLE
Add new "last build" selector

### DIFF
--- a/src/main/java/hudson/plugins/copyartifact/LastCompletedBuildSelector.java
+++ b/src/main/java/hudson/plugins/copyartifact/LastCompletedBuildSelector.java
@@ -1,0 +1,51 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004-2011, Sun Microsystems, Inc., Alan Harder
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.copyartifact;
+
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.model.Result;
+import hudson.model.Run;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Copy artifacts from the latest build (ignoring the build status)
+ * @author Helmut Schaa
+ */
+public class LastCompletedBuildSelector extends BuildSelector {
+
+    @DataBoundConstructor
+    public LastCompletedBuildSelector() { }
+
+    @Override
+    public boolean isSelectable(Run<?,?> run, EnvVars env) {
+        return true;
+    }
+
+    @Extension
+    public static final Descriptor<BuildSelector> DESCRIPTOR =
+            new SimpleBuildSelectorDescriptor(
+                LastCompletedBuildSelector.class, Messages._LastCompletedBuildSelector_DisplayName());
+}

--- a/src/main/resources/hudson/plugins/copyartifact/Messages.properties
+++ b/src/main/resources/hudson/plugins/copyartifact/Messages.properties
@@ -12,6 +12,7 @@ CopyArtifact.MissingSrcWorkspace=Unable to access upstream workspace for artifac
 CopyArtifact.MissingWorkspace=Unable to access workspace for artifact copy. Slave node offline?
 CopyArtifact.ParameterizedName=Value references a build parameter, so it cannot be validated.
 PermalinkBuildSelector.DisplayName=Specified by permalink
+LastCompletedBuildSelector.DisplayName=Last completed build (ignoring build status)
 StatusBuildSelector.DisplayName=Latest successful build
 SavedBuildSelector.DisplayName=Latest saved build (marked "keep forever")
 SpecificBuildSelector.DisplayName=Specific build


### PR DESCRIPTION
Allows to select the last build ignoring the build status completely.
This allows to copy artifacts also from failed jobs.