### PR TITLE
[JENKINS-24487] Allows tests run on Windows

### DIFF
--- a/src/test/java/hudson/plugins/copyartifact/CopyArtifactWorkflowTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/CopyArtifactWorkflowTest.java
@@ -47,7 +47,7 @@ public class CopyArtifactWorkflowTest {
     public void test_simpleUntriggeredCopy() throws Exception {
         // create "project_1" with an archived artifact...
         WorkflowJob project_1 = createWorkflow("project_1",
-                "sh 'echo hello > hello.txt'; " +
+                "writeFile text: 'hello', file: 'hello.txt'; " +
                 "step([$class: 'ArtifactArchiver', artifacts: 'hello.txt', fingerprint: true])");
         WorkflowRun b = jenkinsRule.assertBuildStatusSuccess(project_1.scheduleBuild2(0));
         assertArtifactInArchive(b);


### PR DESCRIPTION
An additional trivial change for #55.

Workflow step `sh` doesn't work on Windows.
Let's use `writeFile` instead: https://github.com/jenkinsci/workflow-plugin/blob/master/basic-steps/src/main/java/org/jenkinsci/plugins/workflow/steps/WriteFileStep.java.