### PR TITLE
[JENKINS-27475] Avoids NPE on renaming a project.

### DIFF
--- a/src/main/java/hudson/plugins/copyartifact/CopyArtifact.java
+++ b/src/main/java/hudson/plugins/copyartifact/CopyArtifact.java
@@ -541,6 +541,10 @@ public class CopyArtifact extends Builder implements SimpleBuildStep {
                 try {
                 for (CopyArtifact ca : getCopiers(project)) {
                     String projectName = ca.getProjectName();
+                    if (projectName == null) {
+                        // JENKINS-27475 (not sure why this happens).
+                        continue;
+                    }
 
                     String suffix = "";
                     // Support rename for "MatrixJobName/AxisName=value" type of name


### PR DESCRIPTION
A fix for [JENKINS-27475](https://issues.jenkins-ci.org/browse/JENKINS-27475).

This NPE happens when:
* `Copyartifact#project` is `null`
* `Copyartifact#projectName` is `null`

As far as I know, this should not be happen. I don't know how to reproduce that NPE.
Though, the fix is easy and harmless, and I plan to include this fix in the next release.