### PR TITLE
[JENKINS-29488] Fixed findbugs issues.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,12 @@
             </exclusion>
         </exclusions>
       </dependency>
+      <!-- to suppress known (and harmless) findbugs issues -->
+      <dependency>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>annotations</artifactId>
+          <version>3.0.0</version>
+      </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,6 @@
                 <version>3.0.1</version>
                 <configuration>
                     <xmlOutput>true</xmlOutput>
-                    <findbugsXmlWithMessages>true</findbugsXmlWithMessages>
                     <failOnError>false</failOnError>
                 </configuration>
             </plugin>

--- a/src/main/java/hudson/plugins/copyartifact/BuildSelector.java
+++ b/src/main/java/hudson/plugins/copyartifact/BuildSelector.java
@@ -28,6 +28,7 @@ import hudson.ExtensionPoint;
 import hudson.FilePath;
 import hudson.Util;
 import hudson.model.AbstractDescribableImpl;
+import hudson.model.Result;
 import hudson.model.Job;
 import hudson.model.Run;
 import java.io.IOException;
@@ -82,6 +83,28 @@ public abstract class BuildSelector extends AbstractDescribableImpl<BuildSelecto
      */
     protected boolean isSelectable(Run<?,?> run, EnvVars env) {
         return false;
+    }
+
+    /**
+     * Wrapper for {@link Result#isBetterOrEqualTo(Result)} with null checks.
+     * 
+     * Returns <code>false</code> if <code>run</code> is <code>null</code>
+     * or <code>run</code> is still running.
+     * 
+     * @param run
+     * @param resultToTest
+     * @return
+     * @see Result#isBetterOrEqualTo(Result)
+     */
+    protected static boolean isBuildResultBetterOrEqualTo(Run<?,?> run, Result resultToTest) {
+        if (run == null) {
+            return false;
+        }
+        Result buildResult = run.getResult();
+        if (buildResult == null) {
+            return false;
+        }
+        return buildResult.isBetterOrEqualTo(resultToTest);
     }
 
     protected FilePath getSourceDirectory(Run<?,?> src, PrintStream console) throws IOException, InterruptedException {

--- a/src/main/java/hudson/plugins/copyartifact/CopyArtifactPermissionProperty.java
+++ b/src/main/java/hudson/plugins/copyartifact/CopyArtifactPermissionProperty.java
@@ -126,7 +126,7 @@ public class CopyArtifactPermissionProperty extends JobProperty<AbstractProject<
         List<String> literals = Arrays.asList(pattern.split("\\*", -1));
         String regex = StringUtils.join(Lists.transform(literals, new Function<String, String>() {
             public String apply(String input) {
-                return Pattern.quote(input);
+                return (input != null)?Pattern.quote(input):"";
             }
         }), ".*");
         return name.matches(regex);
@@ -210,7 +210,8 @@ public class CopyArtifactPermissionProperty extends JobProperty<AbstractProject<
                     // no check for pattern
                     continue;
                 }
-                AbstractProject<?,?> proj = Jenkins.getInstance().getItem(projectName, context, AbstractProject.class);
+                Jenkins jenkins = Jenkins.getInstance();
+                AbstractProject<?,?> proj = (jenkins == null)?null:jenkins.getItem(projectName, context, AbstractProject.class);
                 if (proj == null || proj.getRootProject() != proj || !proj.hasPermission(Item.READ)) {
                     // permission check is done only for root project.
                     notFound.add(projectName);
@@ -243,7 +244,11 @@ public class CopyArtifactPermissionProperty extends JobProperty<AbstractProject<
                 return candidates;
             }
             value = StringUtils.trim(value);
-            for (AbstractProject<?,?> project: Jenkins.getInstance().getAllItems(AbstractProject.class)) {
+            Jenkins jenkins = Jenkins.getInstance();
+            if (jenkins == null) {
+                return candidates;
+            }
+            for (AbstractProject<?,?> project: jenkins.getAllItems(AbstractProject.class)) {
                 if (project.getRootProject() != project) {
                     // permission check is done only for root project.
                     continue;

--- a/src/main/java/hudson/plugins/copyartifact/DownstreamBuildSelector.java
+++ b/src/main/java/hudson/plugins/copyartifact/DownstreamBuildSelector.java
@@ -24,6 +24,7 @@
 
 package hudson.plugins.copyartifact;
 
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import jenkins.model.Jenkins;
@@ -91,9 +92,19 @@ public class DownstreamBuildSelector extends BuildSelector {
             LOGGER.warning(String.format("Only applicable to AbstractBuild: but is %s.", run.getClass().getName()));
             return false;
         }
+        Jenkins jenkins = Jenkins.getInstance();
+        if (jenkins == null) {
+            // to suppress findbugs warnings.
+            LOGGER.log(
+                    Level.SEVERE,
+                    "Jenkins instance isn't available and cannot perform copyartifact from",
+                    run.getDisplayName()
+            );
+            return false;
+        }
         
         // Workaround to retrieve who is copying.
-        Job<?,?> copier = Jenkins.getInstance().getItemByFullName(env.get(COPIER_PROJECT_KEY), Job.class);
+        Job<?,?> copier = jenkins.getItemByFullName(env.get(COPIER_PROJECT_KEY), Job.class);
         if (copier != null && (copier instanceof AbstractProject<?,?>)) {
             copier = ((AbstractProject<?,?>)copier).getRootProject();
         }
@@ -111,7 +122,7 @@ public class DownstreamBuildSelector extends BuildSelector {
             return false;
         }
         
-        AbstractProject<?,?> upstreamProject = Jenkins.getInstance().getItem(
+        AbstractProject<?,?> upstreamProject = jenkins.getItem(
                 projectName,
                 copier,
                 AbstractProject.class
@@ -178,7 +189,13 @@ public class DownstreamBuildSelector extends BuildSelector {
                 return FormValidation.ok();
             }
             
-            AbstractProject<?,?> upstreamProject = Jenkins.getInstance().getItem(
+            Jenkins jenkins = Jenkins.getInstance();
+            if (jenkins == null) {
+                // Jenkins is unavailable and validation is useless.
+                return FormValidation.ok();
+            }
+            
+            AbstractProject<?,?> upstreamProject = jenkins.getItem(
                     upstreamProjectName, project.getRootProject(), AbstractProject.class
             );
             if (upstreamProject == null || !upstreamProject.hasPermission(Item.READ)) {
@@ -215,7 +232,13 @@ public class DownstreamBuildSelector extends BuildSelector {
                 return FormValidation.ok();
             }
             
-            AbstractProject<?,?> upstreamProject = Jenkins.getInstance().getItem(
+            Jenkins jenkins = Jenkins.getInstance();
+            if (jenkins == null) {
+                // Jenkins is unavailable and validation is useless.
+                return FormValidation.ok();
+            }
+            
+            AbstractProject<?,?> upstreamProject = jenkins.getItem(
                     upstreamProjectName, project.getRootProject(), AbstractProject.class
             );
             if (upstreamProject == null || !upstreamProject.hasPermission(Item.READ)) {

--- a/src/main/java/hudson/plugins/copyartifact/FilePathCopyMethod.java
+++ b/src/main/java/hudson/plugins/copyartifact/FilePathCopyMethod.java
@@ -29,6 +29,8 @@ import hudson.model.Run;
 
 import java.io.IOException;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Default implementation of CopyMethod extension point,
  * using the Jenkins FilePath class.  Has -100 ordinal value so any other
@@ -51,6 +53,10 @@ public class FilePathCopyMethod extends Copier {
         source.copyToWithPermission(target);
     }
 
+    @SuppressFBWarnings(
+            value = "CN_IMPLEMENTS_CLONE_BUT_NOT_CLONEABLE",
+            justification = "This is a method not of Cloneable but of Copier."
+    )
     @Override
     public Copier clone() {
         return this;

--- a/src/main/java/hudson/plugins/copyartifact/FingerprintingCopyMethod.java
+++ b/src/main/java/hudson/plugins/copyartifact/FingerprintingCopyMethod.java
@@ -1,5 +1,6 @@
 package hudson.plugins.copyartifact;
 
+import hudson.AbortException;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Util;
@@ -20,6 +21,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
  * Performs fingerprinting during the copy.
@@ -95,7 +98,11 @@ public class FingerprintingCopyMethod extends Copier {
             String digest = Util.toHexString(md5.digest());
 
             if (fingerprintArtifacts) {
-                FingerprintMap map = Jenkins.getInstance().getFingerprintMap();
+                Jenkins jenkins = Jenkins.getInstance();
+                if (jenkins == null) {
+                    throw new AbortException("Jenkins instance no longer exists.");
+                }
+                FingerprintMap map = jenkins.getFingerprintMap();
 
                 Fingerprint f = map.getOrCreate(src, s.getName(), digest);
                 if (src!=null) {
@@ -126,6 +133,10 @@ public class FingerprintingCopyMethod extends Copier {
         }
     }
 
+    @SuppressFBWarnings(
+            value = "CN_IMPLEMENTS_CLONE_BUT_NOT_CLONEABLE",
+            justification = "This is a method not of Cloneable but of Copier."
+    )
     @Override
     public Copier clone() {
         return new FingerprintingCopyMethod();

--- a/src/main/java/hudson/plugins/copyartifact/ParametersBuildFilter.java
+++ b/src/main/java/hudson/plugins/copyartifact/ParametersBuildFilter.java
@@ -31,6 +31,8 @@ import hudson.model.Job;
 import hudson.model.ParametersAction;
 import hudson.model.Run;
 import hudson.model.StringParameterValue;
+
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -66,7 +68,8 @@ public class ParametersBuildFilter extends BuildFilter {
                 }
             }
             return true;
-        } catch (Exception ignore) {
+        } catch (InterruptedException ignore) {
+        } catch (IOException ignore) {
         }
         return false;
     }

--- a/src/main/java/hudson/plugins/copyartifact/PermalinkBuildSelector.java
+++ b/src/main/java/hudson/plugins/copyartifact/PermalinkBuildSelector.java
@@ -66,8 +66,9 @@ public class PermalinkBuildSelector extends BuildSelector {
 
         public ComboBoxModel doFillIdItems(@AncestorInPath Job copyingJob, @RelativePath("..") @QueryParameter("projectName") String projectName) {
             Job j = null;
-            if (projectName != null) {
-                j = Jenkins.getInstance().getItem(projectName, copyingJob, Job.class);
+            Jenkins jenkins = Jenkins.getInstance();
+            if (projectName != null && jenkins != null) {
+                j = jenkins.getItem(projectName, copyingJob, Job.class);
             }
             ComboBoxModel r = new ComboBoxModel();
             for (Permalink p : j != null ? j.getPermalinks() : Permalink.BUILTIN) {

--- a/src/main/java/hudson/plugins/copyartifact/StatusBuildSelector.java
+++ b/src/main/java/hudson/plugins/copyartifact/StatusBuildSelector.java
@@ -48,7 +48,7 @@ public class StatusBuildSelector extends BuildSelector {
 
     @Override
     public boolean isSelectable(Run<?,?> run, EnvVars env) {
-        return run.getResult().isBetterOrEqualTo(isStable() ? Result.SUCCESS : Result.UNSTABLE);
+        return isBuildResultBetterOrEqualTo(run, isStable() ? Result.SUCCESS : Result.UNSTABLE);
     }
 
     @Extension(ordinal=100)


### PR DESCRIPTION
[JENKINS-29488](https://issues.jenkins-ci.org/browse/JENKINS-29488) (findbugs.xml before this fix is attached)
#67 introduced findbugs and revealed that copyartifact have many findbugs issues.

Most of them are `@CheckForNull` for `Jenkins#getInstance` (introduced in fa496c7bf228ecb243acf0135106f18f27132c6f) like:
```
    <BugInstance type='NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE'
        priority='Normal'
        category='STYLE'
        message='Possible null pointer dereference in hudson.plugins.copyartifact.BuildSelectorParameter$DescriptorImpl.getAvailableBuildSelectorList() due to return value of called method'
        lineNumber='105'/>
```

I decided not to use `@SuppressFBWarnings` for this issue as it can annotate only whole methods (annotating local variables takes no effects...) and that can easily cause unexpectedly mask problems in those methods.
I hope the day `@SuppressFBWarnings` is applicable for local variables.

I add comments for changes for issues other than `Jenkins#getInstance`.