### PR TITLE
[JENKINS-18938] Added a field to specify the suffix for the variable to store the build number

### DIFF
--- a/src/main/resources/hudson/plugins/copyartifact/CopyArtifact/config.jelly
+++ b/src/main/resources/hudson/plugins/copyartifact/CopyArtifact/config.jelly
@@ -49,4 +49,9 @@ THE SOFTWARE.
     <f:checkbox field="fingerprintArtifacts" default="true"/>
     <label class="attach-previous">${%Fingerprint Artifacts}</label>
   </f:entry>
+  <f:advanced>
+    <f:entry title="${%Result variable suffix}" field="resultVariableSuffix">
+      <f:textbox/>
+    </f:entry>
+  </f:advanced>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/copyartifact/CopyArtifact/help-resultVariableSuffix.html
+++ b/src/main/resources/hudson/plugins/copyartifact/CopyArtifact/help-resultVariableSuffix.html
@@ -1,0 +1,25 @@
+<div>
+The build number of the selected build will be recorded
+into the variable named <tt>COPYARTIFACT_BUILD_NUMBER_(SUFFIX)</tt>
+for later build steps to reference.
+You can specify that suffix part for that variable here.
+<p>
+If not specified, the source project name will be used instead
+(in all uppercase, and sequences of characters other than A-Z
+replaced by a single underscore).
+<p><strong>Example</strong>:
+<table>
+  <tr>
+    <th>Source project name</th>
+    <th>Suffix to be used</th>
+  </tr>
+  <tr>
+    <td>Project-ABC</td>
+    <td>PROJECT_ABC</td>
+  </tr>
+  <tr>
+    <td>tool1-release1.2</td>
+    <td>TOOL_RELEASE_</td>
+  </tr>
+</table>
+</div>

--- a/src/main/resources/hudson/plugins/copyartifact/CopyArtifact/help-resultVariableSuffix_ja.html
+++ b/src/main/resources/hudson/plugins/copyartifact/CopyArtifact/help-resultVariableSuffix_ja.html
@@ -1,0 +1,23 @@
+<div>
+コピー元のビルドのビルド番号を <tt>COPYARTIFACT_BUILD_NUMBER_(SUFFIX)</tt>
+という変数に保存し、以降のビルド処理で参照できるようにします。
+その際に使用する SUFFIX の部分をここで指定します。
+<p>
+指定しない場合、コピー元のプロジェクト名が使用されます。
+プロジェクト名はすべて大文字、A-Z 以外の文字がすべてアンダースコアに変換されます。
+<p><strong>例</strong>:
+<table>
+  <tr>
+    <th>Source project name</th>
+    <th>Suffix to be used</th>
+  </tr>
+  <tr>
+    <td>Project-ABC</td>
+    <td>PROJECT_ABC</td>
+  </tr>
+  <tr>
+    <td>tool1-release1.2</td>
+    <td>TOOL_RELEASE_</td>
+  </tr>
+</table>
+</div>

--- a/src/main/resources/hudson/plugins/copyartifact/CopyArtifact/help-selector.html
+++ b/src/main/resources/hudson/plugins/copyartifact/CopyArtifact/help-selector.html
@@ -3,17 +3,7 @@
   or stable build, or latest "keep forever" build.  Other plugins may provide
   additional selections. <br/>
   The build number of the selected build will be recorded in the environment
-  for later build steps to reference.  The name of the environment variable
-  is <tt>COPYARTIFACT_BUILD_NUMBER_</tt> with the source project name appended
-  (in all uppercase, and sequences of characters other than A-Z replaced by a 
-  single underscore).
-  <p><strong>Example</strong>:
-  <ul>
-    <li>
-      The build number of the build for the source project <code>Project-ABC</code> is
-      available in <code>COPYARTIFACT_BUILD_NUMBER_PROJECT_ABC</code></li>
-    <li>
-      The build number of the build for the source project <code>tool1-release1.2</code> is
-      available in <code>COPYARTIFACT_BUILD_NUMBER_TOOL_RELEASE_</code></li>
-  </ul>
+  for later build steps to reference.
+  For details, see the help of "Result variable suffix"
+  in "Advanced" section.
 </div>

--- a/src/main/resources/hudson/plugins/copyartifact/Messages.properties
+++ b/src/main/resources/hudson/plugins/copyartifact/Messages.properties
@@ -10,6 +10,7 @@ see help for project name in job configuration.
 CopyArtifact.MissingSrcArtifacts=Unable to access upstream artifacts area {0}. Does source project archive artifacts?
 CopyArtifact.MissingSrcWorkspace=Unable to access upstream workspace for artifact copy. Slave node offline?
 CopyArtifact.ParameterizedName=Value references a build parameter, so it cannot be validated.
+CopyArtifact.InvalidVariableName=Contains letters not applicable for variable names.
 PermalinkBuildSelector.DisplayName=Specified by permalink
 LastCompletedBuildSelector.DisplayName=Last completed build (ignoring build status)
 StatusBuildSelector.DisplayName=Latest successful build

--- a/src/test/java/hudson/plugins/copyartifact/testutils/CopyArtifactUtil.java
+++ b/src/test/java/hudson/plugins/copyartifact/testutils/CopyArtifactUtil.java
@@ -46,7 +46,7 @@ public class CopyArtifactUtil {
 
     public static CopyArtifact createCopyArtifact(String projectName, String parameters, BuildSelector selector, String filter, String excludes, String target,
                         boolean flatten, boolean optional, boolean fingerprintArtifacts) {
-        return createCopyArtifact(projectName, parameters, selector, filter, null, target, flatten, optional, fingerprintArtifacts, null);
+        return createCopyArtifact(projectName, parameters, selector, filter, excludes, target, flatten, optional, fingerprintArtifacts, null);
     }
     
     public static CopyArtifact createCopyArtifact(String projectName, String parameters, BuildSelector selector, String filter, String excludes, String target,

--- a/src/test/java/hudson/plugins/copyartifact/testutils/CopyArtifactUtil.java
+++ b/src/test/java/hudson/plugins/copyartifact/testutils/CopyArtifactUtil.java
@@ -46,6 +46,11 @@ public class CopyArtifactUtil {
 
     public static CopyArtifact createCopyArtifact(String projectName, String parameters, BuildSelector selector, String filter, String excludes, String target,
                         boolean flatten, boolean optional, boolean fingerprintArtifacts) {
+        return createCopyArtifact(projectName, parameters, selector, filter, null, target, flatten, optional, fingerprintArtifacts, null);
+    }
+    
+    public static CopyArtifact createCopyArtifact(String projectName, String parameters, BuildSelector selector, String filter, String excludes, String target,
+                        boolean flatten, boolean optional, boolean fingerprintArtifacts, String resultVariableSuffix) {
         CopyArtifact copyArtifact = new CopyArtifact(projectName);
         copyArtifact.setParameters(parameters);
         copyArtifact.setSelector(selector);
@@ -55,6 +60,7 @@ public class CopyArtifactUtil {
         copyArtifact.setFlatten(flatten);
         copyArtifact.setOptional(optional);
         copyArtifact.setFingerprintArtifacts(fingerprintArtifacts);
+        copyArtifact.setResultVariableSuffix(resultVariableSuffix);
         return copyArtifact;
     }
 }


### PR DESCRIPTION
[JENKINS-18938](https://issues.jenkins-ci.org/browse/JENKINS-18938)
Copyartifact stores the number of the build where copied artifacts to a variable "COPYARTIFACT_BUILD_NUMBER_(PROJECTNAME)".
Not all project names are usable for variable names and copyartifact substitutes invalid letters in project names.
That contains following problems;
* It's difficult for users to know the actual variable name where the build number is stored.
    * Especially when the source project is in different folder.
* "Invalid letters" contain numeric letters even though they are actually usable for variable names.

This change introduces a new field "Result variable suffix" which specified the suffix for "COPYARTIFACT_BUILD_NUMBER_(SUFFIX)".

* It is located in "Advanced" section.
    ![resultvariablesuffix-1](https://cloud.githubusercontent.com/assets/3115961/9170181/ad1949b0-3f9b-11e5-8f4c-d5d9eec0308c.png)
* You can specify the suffix for the variable name. 
![resultvariablesuffix-2](https://cloud.githubusercontent.com/assets/3115961/9170185/b10da2b4-3f9b-11e5-9d06-308eacd9bea4.png)

If nothing is specified or invalid one is specified, the project name is used as the suffix just like the existing behavior.
This keeps the backward compatibility.
