### PR TITLE
[JENKINS-30357] Fixed NPE and other improvements in ParameterizedBuildSelector

### DIFF
--- a/src/main/java/hudson/plugins/copyartifact/ParameterizedBuildSelector.java
+++ b/src/main/java/hudson/plugins/copyartifact/ParameterizedBuildSelector.java
@@ -23,11 +23,15 @@
  */
 package hudson.plugins.copyartifact;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.model.Job;
 import hudson.model.Run;
+
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -37,6 +41,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
  */
 public class ParameterizedBuildSelector extends BuildSelector {
     private String parameterName;
+    private static final Logger LOG = Logger.getLogger(ParameterizedBuildSelector.class.getName());
 
     @DataBoundConstructor
     public ParameterizedBuildSelector(String parameterName) {
@@ -49,7 +54,12 @@ public class ParameterizedBuildSelector extends BuildSelector {
 
     @Override
     public Run<?,?> getBuild(Job<?,?> job, EnvVars env, BuildFilter filter, Run<?,?> parent) {
-        return BuildSelectorParameter.getSelectorFromXml(env.get(parameterName))
+        String xml = env.get(getParameterName());
+        if (xml == null) {
+            LOG.log(Level.WARNING, "{0} is not defined", getParameterName());
+            return null;
+        }
+        return BuildSelectorParameter.getSelectorFromXml(xml)
                                      .getBuild(job, env, filter, parent);
     }
 

--- a/src/main/java/hudson/plugins/copyartifact/ParameterizedBuildSelector.java
+++ b/src/main/java/hudson/plugins/copyartifact/ParameterizedBuildSelector.java
@@ -59,8 +59,14 @@ public class ParameterizedBuildSelector extends BuildSelector {
             LOG.log(Level.WARNING, "{0} is not defined", getParameterName());
             return null;
         }
-        return BuildSelectorParameter.getSelectorFromXml(xml)
-                                     .getBuild(job, env, filter, parent);
+        BuildSelector selector = null;
+        try {
+            selector = BuildSelectorParameter.getSelectorFromXml(xml);
+        } catch (Exception e) {
+            LOG.log(Level.SEVERE, String.format("Failed to resolve selector: %s", xml), e);
+            return null;
+        }
+        return selector.getBuild(job, env, filter, parent);
     }
 
     @Extension(ordinal=-20)

--- a/src/main/resources/hudson/plugins/copyartifact/ParameterizedBuildSelector/help-parameterName.html
+++ b/src/main/resources/hudson/plugins/copyartifact/ParameterizedBuildSelector/help-parameterName.html
@@ -2,4 +2,7 @@
   Name of the "build selector" parameter.  A parameter with this name should be added
   in the build parameters section above.  There is a special parameter type for choosing
   the build selector.
+  <p>
+  You can pass not only the parameter name, but also the parameter value itself.
+  This is useful especially used with workflow-plugin.
 </div>

--- a/src/test/java/hudson/plugins/copyartifact/ParameterizedBuildSelectorTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/ParameterizedBuildSelectorTest.java
@@ -1,0 +1,120 @@
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2015 IKEDA Yasuyuki
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.plugins.copyartifact;
+
+import static org.junit.Assert.*;
+import jenkins.util.VirtualFile;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.ParametersAction;
+import hudson.model.StringParameterValue;
+import hudson.plugins.copyartifact.testutils.CopyArtifactUtil;
+import hudson.plugins.copyartifact.testutils.FileWriteBuilder;
+import hudson.tasks.ArtifactArchiver;
+import hudson.util.IOUtils;
+
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+/**
+ * Tests for {@link ParameterizedBuildSelector}
+ * 
+ * @see CopyArtifactTest#testParameterizedBuildSelector()
+ */
+public class ParameterizedBuildSelectorTest {
+    @ClassRule
+    public static JenkinsRule j = new JenkinsRule();
+    
+    /**
+     * Should not cause a fatal error even for an undefined variable.
+     * 
+     * @throws Exception
+     */
+    @Issue("JENKINS-30357")
+    @Test
+    public void testUndefinedParameter() throws Exception {
+        FreeStyleProject copiee = j.createFreeStyleProject();
+        FreeStyleProject copier = j.createFreeStyleProject();
+        
+        ParameterizedBuildSelector pbs = new ParameterizedBuildSelector("NosuchVariable");
+        copier.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(
+                copiee.getFullName(),
+                null,   // parameters
+                pbs,
+                "**/*", // filter
+                "",     // excludes
+                false,  // flatten
+                true,   // optional
+                false   // finterprintArtifacts
+        ));
+        FreeStyleBuild b = copier.scheduleBuild2(0).get();
+        j.assertBuildStatusSuccess(b);
+    }
+    
+    /**
+     * Also applicable for workflow jobs.
+     * 
+     * @throws Exception
+     */
+    @Issue("JENKINS-30357")
+    @Test
+    public void testWorkflow() throws Exception {
+        // Prepare an artifact to be copied.
+        FreeStyleProject copiee = j.createFreeStyleProject("copiee");
+        copiee.getBuildersList().add(new FileWriteBuilder("artifact.txt", "foobar"));
+        copiee.getPublishersList().add(new ArtifactArchiver("artifact.txt"));
+        j.assertBuildStatusSuccess(copiee.scheduleBuild2(0));
+        
+        WorkflowJob copier = j.jenkins.createProject(WorkflowJob.class, "copier");
+        copier.setDefinition(new CpsFlowDefinition(
+                "node {"
+                    + "step([$class: 'CopyArtifact',"
+                        + "projectName: 'copiee',"
+                        + "filter: '**/*',"
+                        + "selector: [$class: 'ParameterizedBuildSelector', parameterName: 'SELECTOR'],"
+                    + "]);"
+                    + "step([$class: 'ArtifactArchiver', artifacts: '**/*']);"
+                + "}",
+                true
+        ));
+        
+        WorkflowRun b = j.assertBuildStatusSuccess(copier.scheduleBuild2(
+                0,
+                null,
+                new ParametersAction(new StringParameterValue(
+                        "SELECTOR",
+                        "<StatusBuildSelector><stable>true</stable></StatusBuildSelector>"
+                ))
+        ));
+        
+        VirtualFile vf = b.getArtifactManager().root().child("artifact.txt");
+        assertEquals("foobar", IOUtils.toString(vf.open()));
+    }
+}

--- a/src/test/java/hudson/plugins/copyartifact/ParameterizedBuildSelectorTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/ParameterizedBuildSelectorTest.java
@@ -117,4 +117,95 @@ public class ParameterizedBuildSelectorTest {
         VirtualFile vf = b.getArtifactManager().root().child("artifact.txt");
         assertEquals("foobar", IOUtils.toString(vf.open()));
     }
+    
+    /**
+     * Should not cause a fatal error even for a broken selector.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testBrokenParameter() throws Exception {
+        FreeStyleProject copiee = j.createFreeStyleProject();
+        FreeStyleProject copier = j.createFreeStyleProject();
+        
+        ParameterizedBuildSelector pbs = new ParameterizedBuildSelector("SELECTOR");
+        copier.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(
+                copiee.getFullName(),
+                null,   // parameters
+                pbs,
+                "**/*", // filter
+                "",     // excludes
+                false,  // flatten
+                true,   // optional
+                false   // finterprintArtifacts
+        ));
+        FreeStyleBuild b = (FreeStyleBuild) copier.scheduleBuild2(
+                0,
+                new ParametersAction(
+                    new StringParameterValue("SELECTOR", "<SomeBrokenSelector")
+                )
+        ).get();
+        j.assertBuildStatusSuccess(b);
+    }
+    
+    /**
+     * Should not cause a fatal error even for an unavailable selector.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testUnavailableSelector() throws Exception {
+        FreeStyleProject copiee = j.createFreeStyleProject();
+        FreeStyleProject copier = j.createFreeStyleProject();
+        
+        ParameterizedBuildSelector pbs = new ParameterizedBuildSelector("SELECTOR");
+        copier.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(
+                copiee.getFullName(),
+                null,   // parameters
+                pbs,
+                "**/*", // filter
+                "",     // excludes
+                false,  // flatten
+                true,   // optional
+                false   // finterprintArtifacts
+        ));
+        FreeStyleBuild b = (FreeStyleBuild) copier.scheduleBuild2(
+                0,
+                new ParametersAction(
+                    new StringParameterValue("SELECTOR", "<NoSuchSelector />")
+                )
+        ).get();
+        j.assertBuildStatusSuccess(b);
+    }
+    
+    
+    /**
+     * Should not cause a fatal error even for an empty selector.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testEmptySelector() throws Exception {
+        FreeStyleProject copiee = j.createFreeStyleProject();
+        FreeStyleProject copier = j.createFreeStyleProject();
+        
+        ParameterizedBuildSelector pbs = new ParameterizedBuildSelector("SELECTOR");
+        copier.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(
+                copiee.getFullName(),
+                null,   // parameters
+                pbs,
+                "**/*", // filter
+                "",     // excludes
+                false,  // flatten
+                true,   // optional
+                false   // finterprintArtifacts
+        ));
+        FreeStyleBuild b = (FreeStyleBuild) copier.scheduleBuild2(
+                0,
+                new ParametersAction(
+                    new StringParameterValue("SELECTOR", "")
+                )
+        ).get();
+        j.assertBuildStatusSuccess(b);
+    }
 }


### PR DESCRIPTION
[JENKINS-30357](https://issues.jenkins-ci.org/browse/JENKINS-30357)

Fixed:
* ParameterizedBuildSelector doesn't work with workflow jobs as parameter variables in workflow jobs are not passed to copyartifact.
* NPE when specifying an undefined variable in ParameterizedBuildSelector.

Improved:
* Error handlings in ParameterizedBuildSelector

New features:
* You can specify immediate values (like `<SomeSelector />`) in ParameterizedBuildSelector. This is useful especially with workflow jobs, you can pass values with `${SELECTOR}` in workflow definitions.
* You can specify variable expression (like `${SELECTOR}`) in ParameterizedBuildSelector. This is to allow users to configure ParameterizedBuildSelector in freestyle projects just like workflow jobs. (to keep the compatibility of usage with workflow jobs)
    * I agree this is an incomplete feature as values like `<${SelectorName} />` doesn't work as expected. It will be considered an immediate value.
