### PR TITLE
Add missing credentials dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,12 @@
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>credentials</artifactId>
+        <version>1.8.3</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>matrix-project</artifactId>
         <version>1.3</version>
       </dependency>


### PR DESCRIPTION
The tests for any class using FolderCredentials was failing with a
ClassDefNotFound.  This happens because the credentials plugin is
"optional" for the cloudbees-folder plugin (which is used by this class
for testing only).  The credentials plugin also has to be included in
the pom for test.