### PR TITLE
Add option to 'Upstream build that triggered this job' to allow upstream dependencies

### DIFF
--- a/src/main/java/hudson/plugins/copyartifact/TriggeredBuildSelector.java
+++ b/src/main/java/hudson/plugins/copyartifact/TriggeredBuildSelector.java
@@ -95,13 +95,13 @@ public class TriggeredBuildSelector extends BuildSelector {
     };
     private Boolean fallbackToLastSuccessful;
     private final UpstreamFilterStrategy upstreamFilterStrategy;
-    private Boolean allowUpstreamDependencies;
+    private boolean allowUpstreamDependencies;
 
     @DataBoundConstructor
     public TriggeredBuildSelector(boolean fallbackToLastSuccessful, UpstreamFilterStrategy upstreamFilterStrategy, boolean allowUpstreamDependencies) {
         this.fallbackToLastSuccessful = fallbackToLastSuccessful ? Boolean.TRUE : null;
         this.upstreamFilterStrategy = upstreamFilterStrategy;
-        this.allowUpstreamDependencies = allowUpstreamDependencies ? Boolean.TRUE : null;
+        this.allowUpstreamDependencies = allowUpstreamDependencies;
     }
 
     @Deprecated
@@ -143,7 +143,7 @@ public class TriggeredBuildSelector extends BuildSelector {
     }
     
     public boolean isAllowUpstreamDependencies() {
-        return allowUpstreamDependencies != null && allowUpstreamDependencies.booleanValue();
+        return allowUpstreamDependencies;
     }
     
     @Override

--- a/src/main/java/hudson/plugins/copyartifact/TriggeredBuildSelector.java
+++ b/src/main/java/hudson/plugins/copyartifact/TriggeredBuildSelector.java
@@ -27,12 +27,14 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import jenkins.model.Jenkins;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.model.Result;
 import hudson.model.AbstractProject;
+import hudson.model.AbstractBuild;
 import hudson.model.Cause;
 import hudson.model.Cause.UpstreamCause;
 import hudson.model.Job;
@@ -93,16 +95,18 @@ public class TriggeredBuildSelector extends BuildSelector {
     };
     private Boolean fallbackToLastSuccessful;
     private final UpstreamFilterStrategy upstreamFilterStrategy;
+    private Boolean allowUpstreamDependencies;
 
     @DataBoundConstructor
-    public TriggeredBuildSelector(boolean fallbackToLastSuccessful, UpstreamFilterStrategy upstreamFilterStrategy) {
+    public TriggeredBuildSelector(boolean fallbackToLastSuccessful, UpstreamFilterStrategy upstreamFilterStrategy, boolean allowUpstreamDependencies) {
         this.fallbackToLastSuccessful = fallbackToLastSuccessful ? Boolean.TRUE : null;
         this.upstreamFilterStrategy = upstreamFilterStrategy;
+        this.allowUpstreamDependencies = allowUpstreamDependencies ? Boolean.TRUE : null;
     }
 
     @Deprecated
     public TriggeredBuildSelector(boolean fallback) {
-        this(fallback, UpstreamFilterStrategy.UseGlobalSetting);
+        this(fallback, UpstreamFilterStrategy.UseGlobalSetting, false);
     }
     
     public boolean isFallbackToLastSuccessful() {
@@ -115,7 +119,7 @@ public class TriggeredBuildSelector extends BuildSelector {
     public UpstreamFilterStrategy getUpstreamFilterStrategy() {
         return upstreamFilterStrategy;
     }
-    
+
     /**
      * @return whether to use the newest upstream or not (use the oldest) when there are multiple upstreams.
      */
@@ -138,69 +142,61 @@ public class TriggeredBuildSelector extends BuildSelector {
         }
     }
     
+    public boolean isAllowUpstreamDependencies() {
+        return allowUpstreamDependencies != null && allowUpstreamDependencies.booleanValue();
+    }
+    
     @Override
     public Run<?,?> getBuild(Job<?,?> job, EnvVars env, BuildFilter filter, Run<?,?> parent) {
         Run<?,?> result = null;
+
         // Upstream job for matrix will be parent project, not only individual configuration:
         List<String> jobNames = new ArrayList<String>();
         jobNames.add(job.getFullName());
         if ((job instanceof AbstractProject<?,?>) && ((AbstractProject<?,?>)job).getRootProject() != job) {
             jobNames.add(((AbstractProject<?,?>)job).getRootProject().getFullName());
         }
+
+        List<Run<?, ?>> upstreamBuilds = new ArrayList<Run<?, ?>>();
+
         for (Cause cause: parent.getCauses()) {
             if (cause instanceof UpstreamCause) {
                 UpstreamCause upstream = (UpstreamCause) cause;
-                String upstreamProject = upstream.getUpstreamProject();
-                int upstreamBuild = upstream.getUpstreamBuild();
-                if (jobNames.contains(upstreamProject)) {
-                    Run<?,?> run = job.getBuildByNumber(upstreamBuild);
-                    if (run != null && filter.isSelectable(run, env)){
-                        if (
-                                (result == null)
-                                || (isUseNewest() && result.getNumber() < run.getNumber())
-                                || (!isUseNewest() && result.getNumber() > run.getNumber())
-                        ) {
-                            result = run;
-                        }
-                    }
-                } else {
-                    // Figure out the parent job and do a recursive call to getBuild
-                    Jenkins jenkins = Jenkins.getInstance();
-                    if (jenkins == null) {
-                        // to suppress findbugs warnings.
-                        LOGGER.log(
-                                Level.SEVERE,
-                                "Jenkins instance is unavailable and cannot perform copyartifact from {0} for {1}",
-                                new Object[] {
-                                        job.getFullName(),
-                                        parent.getDisplayName(),
-                                }
-                        );
-                        return null;
-                    }
-                    Job<?,?> parentJob = jenkins.getItemByFullName(upstreamProject, Job.class);
-                    if (parentJob == null) {
-                        LOGGER.log(Level.WARNING, "Upstream project doesn't exist (may be removed): {0}", upstreamProject);
-                        continue;
-                    }
-                    if (parentJob.getBuildByNumber(upstreamBuild) == null) {
-                        LOGGER.log(Level.WARNING, "Upstream build doesn't exist (may be removed): {0} #{1}", new Object[]{upstreamProject, upstreamBuild});
-                        continue;
-                    }
-                    Run<?,?> run = getBuild(
-                        job,
-                        env,
-                        filter,
-                        parentJob.getBuildByNumber(upstreamBuild));
-                    if (run != null && filter.isSelectable(run, env)) {
-                        if (
-                                (result == null)
-                                || (isUseNewest() && result.getNumber() < run.getNumber())
-                                || (!isUseNewest() && result.getNumber() > run.getNumber())
-                        ) {
-                            result = run;
-                        }
-                    }
+                Run<?, ?> upstreamRun = upstream.getUpstreamRun();
+                if (upstreamRun != null) {
+                    upstreamBuilds.add(upstreamRun);
+                }
+            }
+        }
+
+        if (isAllowUpstreamDependencies() && (parent instanceof AbstractBuild)) {
+            AbstractBuild<?, ?> parentBuild = (AbstractBuild<?,?>)parent;
+            
+            Map<AbstractProject, Integer> parentUpstreamBuilds = parentBuild.getUpstreamBuilds();
+            for (AbstractProject project : parentUpstreamBuilds.keySet()) {
+                upstreamBuilds.add(project.getBuildByNumber(parentUpstreamBuilds.get(project)));
+            }
+
+        }
+
+        for (Run<?, ?> upstreamBuild : upstreamBuilds) {
+            Run<?,?> run = null;
+
+            if (jobNames.contains(upstreamBuild.getParent().getFullName())) {
+                // Use the 'job' parameter instead of directly the 'upstreamBuild', because of Matrix jobs.
+                run = job.getBuildByNumber(upstreamBuild.getNumber());
+            } else {
+                // Figure out the parent job and do a recursive call to getBuild
+                run = getBuild(job, env, filter, upstreamBuild);
+            }
+
+            if (run != null && filter.isSelectable(run, env)){
+                if (
+                        (result == null)
+                        || (isUseNewest() && result.getNumber() < run.getNumber())
+                        || (!isUseNewest() && result.getNumber() > run.getNumber())
+                ) {
+                    result = run;
                 }
             }
         }

--- a/src/main/java/hudson/plugins/copyartifact/TriggeredBuildSelector.java
+++ b/src/main/java/hudson/plugins/copyartifact/TriggeredBuildSelector.java
@@ -105,6 +105,11 @@ public class TriggeredBuildSelector extends BuildSelector {
     }
 
     @Deprecated
+    public TriggeredBuildSelector(boolean fallbackToLastSuccessful, UpstreamFilterStrategy upstreamFilterStrategy) {
+        this(fallbackToLastSuccessful, upstreamFilterStrategy, false);
+    }
+
+    @Deprecated
     public TriggeredBuildSelector(boolean fallback) {
         this(fallback, UpstreamFilterStrategy.UseGlobalSetting, false);
     }

--- a/src/main/java/hudson/plugins/copyartifact/TriggeredBuildSelector.java
+++ b/src/main/java/hudson/plugins/copyartifact/TriggeredBuildSelector.java
@@ -178,8 +178,8 @@ public class TriggeredBuildSelector extends BuildSelector {
             AbstractBuild<?, ?> parentBuild = (AbstractBuild<?,?>)parent;
             
             Map<AbstractProject, Integer> parentUpstreamBuilds = parentBuild.getUpstreamBuilds();
-            for (AbstractProject project : parentUpstreamBuilds.keySet()) {
-                upstreamBuilds.add(project.getBuildByNumber(parentUpstreamBuilds.get(project)));
+            for (Map.Entry<AbstractProject, Integer> buildEntry : parentUpstreamBuilds.entrySet()) {
+                upstreamBuilds.add(buildEntry.getKey().getBuildByNumber(buildEntry.getValue()));
             }
 
         }

--- a/src/main/resources/hudson/plugins/copyartifact/TriggeredBuildSelector/config.jelly
+++ b/src/main/resources/hudson/plugins/copyartifact/TriggeredBuildSelector/config.jelly
@@ -30,5 +30,8 @@ THE SOFTWARE.
   <f:entry field="upstreamFilterStrategy" title="${%Which for multiple upstream}">
     <f:enum field="upstreamFilterStrategy">${it.displayName}</f:enum>
   </f:entry>
+  <f:entry field="allowUpstreamDependencies">
+    <f:checkbox title="${%Allow upstream build whose artifacts feed into this build}"/>
+  </f:entry>
   </f:advanced>
 </j:jelly>

--- a/src/test/java/hudson/plugins/copyartifact/DownstreamBuildSelectorTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/DownstreamBuildSelectorTest.java
@@ -133,7 +133,8 @@ public class DownstreamBuildSelectorTest {
                 "",
                 new TriggeredBuildSelector(
                         false,
-                        TriggeredBuildSelector.UpstreamFilterStrategy.UseNewest
+                        TriggeredBuildSelector.UpstreamFilterStrategy.UseNewest,
+                        false
                 ),
                 "**/*",
                 "",
@@ -302,7 +303,8 @@ public class DownstreamBuildSelectorTest {
                 "",
                 new TriggeredBuildSelector(
                         false,
-                        TriggeredBuildSelector.UpstreamFilterStrategy.UseNewest
+                        TriggeredBuildSelector.UpstreamFilterStrategy.UseNewest,
+                        false
                 ),
                 "**/*",
                 "",
@@ -448,7 +450,8 @@ public class DownstreamBuildSelectorTest {
                 "",
                 new TriggeredBuildSelector(
                         false,
-                        TriggeredBuildSelector.UpstreamFilterStrategy.UseNewest
+                        TriggeredBuildSelector.UpstreamFilterStrategy.UseNewest,
+                        false
                 ),
                 "**/*",
                 "",

--- a/src/test/java/hudson/plugins/copyartifact/TriggeredBuildSelectorTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/TriggeredBuildSelectorTest.java
@@ -27,6 +27,8 @@ package hudson.plugins.copyartifact;
 import static org.junit.Assert.*;
 
 import java.util.Arrays;
+import java.io.File;
+import org.apache.commons.io.FileUtils;
 
 import hudson.Util;
 import hudson.maven.MavenModuleSet;
@@ -48,6 +50,7 @@ import org.jvnet.hudson.test.Bug;
 import org.jvnet.hudson.test.ExtractResourceSCM;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
+import org.jvnet.hudson.test.SleepBuilder;
 
 /**
  * Tests for {@link TriggeredBuildSelector}.
@@ -69,7 +72,7 @@ public class TriggeredBuildSelectorTest {
             p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(
                     "${upstream}",
                     "",
-                    new TriggeredBuildSelector(true, TriggeredBuildSelector.UpstreamFilterStrategy.UseOldest),
+                    new TriggeredBuildSelector(true, TriggeredBuildSelector.UpstreamFilterStrategy.UseOldest, false),
                     "",
                     "",
                     false,
@@ -100,7 +103,7 @@ public class TriggeredBuildSelectorTest {
             p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(
                     "${upstream}",
                     "",
-                    new TriggeredBuildSelector(false, TriggeredBuildSelector.UpstreamFilterStrategy.UseNewest),
+                    new TriggeredBuildSelector(false, TriggeredBuildSelector.UpstreamFilterStrategy.UseNewest, false),
                     "",
                     "",
                     false,
@@ -131,7 +134,7 @@ public class TriggeredBuildSelectorTest {
             p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(
                     "${upstream}",
                     "",
-                    new TriggeredBuildSelector(true, TriggeredBuildSelector.UpstreamFilterStrategy.UseGlobalSetting),
+                    new TriggeredBuildSelector(true, TriggeredBuildSelector.UpstreamFilterStrategy.UseGlobalSetting, false),
                     "",
                     "",
                     false,
@@ -186,7 +189,7 @@ public class TriggeredBuildSelectorTest {
         downstream.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(
                 upstream.getName(),
                 "",
-                new TriggeredBuildSelector(false, TriggeredBuildSelector.UpstreamFilterStrategy.UseOldest),
+                new TriggeredBuildSelector(false, TriggeredBuildSelector.UpstreamFilterStrategy.UseOldest, false),
                 "artifact.txt",
                 "",
                 false,
@@ -235,7 +238,7 @@ public class TriggeredBuildSelectorTest {
         downstream.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(
                 upstream.getName(),
                 "",
-                new TriggeredBuildSelector(false, TriggeredBuildSelector.UpstreamFilterStrategy.UseGlobalSetting),
+                new TriggeredBuildSelector(false, TriggeredBuildSelector.UpstreamFilterStrategy.UseGlobalSetting, false),
                 "artifact.txt",
                 "",
                 false,
@@ -282,7 +285,7 @@ public class TriggeredBuildSelectorTest {
         downstream.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(
                 upstream.getName(),
                 "",
-                new TriggeredBuildSelector(false, TriggeredBuildSelector.UpstreamFilterStrategy.UseNewest),
+                new TriggeredBuildSelector(false, TriggeredBuildSelector.UpstreamFilterStrategy.UseNewest, false),
                 "artifact.txt",
                 "",
                 false,
@@ -331,7 +334,7 @@ public class TriggeredBuildSelectorTest {
         downstream.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(
                 upstream.getName(),
                 "",
-                new TriggeredBuildSelector(false, TriggeredBuildSelector.UpstreamFilterStrategy.UseGlobalSetting),
+                new TriggeredBuildSelector(false, TriggeredBuildSelector.UpstreamFilterStrategy.UseGlobalSetting, false),
                 "artifact.txt",
                 "",
                 false,
@@ -388,7 +391,7 @@ public class TriggeredBuildSelectorTest {
         downstream.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(
                 upstream.getName(),
                 "",
-                new TriggeredBuildSelector(false, TriggeredBuildSelector.UpstreamFilterStrategy.UseOldest),
+                new TriggeredBuildSelector(false, TriggeredBuildSelector.UpstreamFilterStrategy.UseOldest, false),
                 "artifact.txt",
                 "",
                 false,
@@ -475,7 +478,7 @@ public class TriggeredBuildSelectorTest {
         downstream.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(
                 upstream.getName(),
                 "",
-                new TriggeredBuildSelector(false, TriggeredBuildSelector.UpstreamFilterStrategy.UseNewest),
+                new TriggeredBuildSelector(false, TriggeredBuildSelector.UpstreamFilterStrategy.UseNewest, false),
                 "artifact.txt",
                 "",
                 false,
@@ -555,7 +558,7 @@ public class TriggeredBuildSelectorTest {
         downstream.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(
                 upstream.getName(),
                 "",
-                new TriggeredBuildSelector(false, null),
+                new TriggeredBuildSelector(false, null, false),
                 "artifact.txt",
                 "",
                 false,
@@ -602,24 +605,139 @@ public class TriggeredBuildSelectorTest {
         TriggeredBuildSelector.DescriptorImpl d = (TriggeredBuildSelector.DescriptorImpl)j.jenkins.getDescriptorOrDie(TriggeredBuildSelector.class);
         
         d.setGlobalUpstreamFilterStrategy(null);
-        assertFalse(new TriggeredBuildSelector(false, null).isUseNewest());
+        assertFalse(new TriggeredBuildSelector(false, null, false).isUseNewest());
         
         d.setGlobalUpstreamFilterStrategy(TriggeredBuildSelector.UpstreamFilterStrategy.UseGlobalSetting);
-        assertFalse(new TriggeredBuildSelector(false, TriggeredBuildSelector.UpstreamFilterStrategy.UseGlobalSetting).isUseNewest());
+        assertFalse(new TriggeredBuildSelector(false, TriggeredBuildSelector.UpstreamFilterStrategy.UseGlobalSetting, false).isUseNewest());
         
         d.setGlobalUpstreamFilterStrategy(TriggeredBuildSelector.UpstreamFilterStrategy.UseOldest);
-        assertFalse(new TriggeredBuildSelector(false, TriggeredBuildSelector.UpstreamFilterStrategy.UseGlobalSetting).isUseNewest());
+        assertFalse(new TriggeredBuildSelector(false, TriggeredBuildSelector.UpstreamFilterStrategy.UseGlobalSetting, false).isUseNewest());
         
         d.setGlobalUpstreamFilterStrategy(TriggeredBuildSelector.UpstreamFilterStrategy.UseNewest);
-        assertTrue(new TriggeredBuildSelector(false, TriggeredBuildSelector.UpstreamFilterStrategy.UseGlobalSetting).isUseNewest());
+        assertTrue(new TriggeredBuildSelector(false, TriggeredBuildSelector.UpstreamFilterStrategy.UseGlobalSetting, false).isUseNewest());
         
         d.setGlobalUpstreamFilterStrategy(TriggeredBuildSelector.UpstreamFilterStrategy.UseOldest);
-        assertTrue(new TriggeredBuildSelector(false, TriggeredBuildSelector.UpstreamFilterStrategy.UseNewest).isUseNewest());
+        assertTrue(new TriggeredBuildSelector(false, TriggeredBuildSelector.UpstreamFilterStrategy.UseNewest, false).isUseNewest());
         
         d.setGlobalUpstreamFilterStrategy(TriggeredBuildSelector.UpstreamFilterStrategy.UseNewest);
-        assertFalse(new TriggeredBuildSelector(false, TriggeredBuildSelector.UpstreamFilterStrategy.UseOldest).isUseNewest());
+        assertFalse(new TriggeredBuildSelector(false, TriggeredBuildSelector.UpstreamFilterStrategy.UseOldest, false).isUseNewest());
     }
     
+    private String getDownstreamAfterOverlappingFlow(boolean allowUpstreamDependencies) throws Exception {
+        //
+        //     upstream   |   intermediate   |   downstream
+        //
+        // Initital build
+        // 1     #1 -------.
+        // 2               '-----> #1 ---------.
+        // 3                                   '-----> #1
+        //
+        // Direct trigger of intermediate, then upstream
+        // 4                 *---> #2 -------.
+        // 5     #2 -----.                   |
+        // 6             |                   '-------> #2
+        // 7             '-------> #3 -----.
+        // 8                               '---------> #3
+        //
+
+        FreeStyleProject upstream = j.createFreeStyleProject("upstream");
+        FreeStyleProject intermediate = j.createFreeStyleProject("intermediate");
+        FreeStyleProject downstream = j.createFreeStyleProject("downstream");
+
+        upstream.getBuildersList().add(new FileWriteBuilder("artifact.txt", "${CONTENT}"));
+        upstream.getPublishersList().add(new ArtifactArchiver("artifact.txt", "", false, false));
+        upstream.getPublishersList().add(new BuildTrigger(intermediate.getName(), Result.SUCCESS));
+        upstream.setQuietPeriod(0);
+
+        intermediate.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(
+                upstream.getName(),
+                "",
+                new TriggeredBuildSelector(true, TriggeredBuildSelector.UpstreamFilterStrategy.UseGlobalSetting, allowUpstreamDependencies),
+                "artifact.txt",
+                "",
+                false,
+                false,
+                true
+        ));        
+        intermediate.getBuildersList().add(new SleepBuilder(1000));
+        intermediate.getPublishersList().add(new ArtifactArchiver("artifact.txt", "", false, false));
+        intermediate.getPublishersList().add(new BuildTrigger(downstream.getName(), Result.SUCCESS));
+        intermediate.setQuietPeriod(0);
+        
+        downstream.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(
+                upstream.getName(),
+                "",
+                new TriggeredBuildSelector(true, TriggeredBuildSelector.UpstreamFilterStrategy.UseGlobalSetting, allowUpstreamDependencies),
+                "artifact.txt",
+                "upstream/",
+                false,
+                false,
+                true
+        ));
+        downstream.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(
+                intermediate.getName(),
+                "",
+                new TriggeredBuildSelector(true, TriggeredBuildSelector.UpstreamFilterStrategy.UseGlobalSetting, allowUpstreamDependencies),
+                "artifact.txt",
+                "intermediate/",
+                false,
+                false,
+                true
+        ));
+        downstream.getPublishersList().add(new ArtifactArchiver("upstream/artifact.txt,intermediate/artifact.txt", "", false, false));
+        downstream.setQuietPeriod(0);
+        
+        upstream.save();
+        intermediate.save();
+        downstream.save();
+        j.jenkins.rebuildDependencyGraph();
+
+        // First (initial) build for each job
+        j.assertBuildStatusSuccess(upstream.scheduleBuild2(0, new Cause.UserCause(), new ParametersAction(new StringParameterValue("CONTENT", "upstreamValue1"))));
+        
+        j.waitUntilNoActivity();
+
+        // Trigger directly an 'intermediate#2' build, which depends on 'upstream#1'
+        intermediate.scheduleBuild2(0, new Cause.UserCause()).waitForStart();
+
+        // 'intermediate#2' build is running. Meanwhile, a new 'upstream#2' is completing and triggers 'intermediate#3':
+        upstream.scheduleBuild2(0, new Cause.UserCause(), new ParametersAction(new StringParameterValue("CONTENT", "upstreamValue2")));
+        
+        j.waitUntilNoActivity();
+
+        assertEquals("Number of upstream builds", 2, upstream.getBuilds().size());
+        assertEquals("Number of intermediate builds", 3, intermediate.getBuilds().size());
+        assertEquals("Number of downstream builds", 3, downstream.getBuilds().size());
+
+        // Get the 'downstream#2' build ...
+        FreeStyleBuild downstreamBuild2 = downstream.getBuildByNumber(2);
+        assertNotNull(downstreamBuild2);
+        j.assertBuildStatusSuccess(downstreamBuild2);
+        // ... that were triggered by the directly triggered 'intermediate#2' build.
+        Cause.UpstreamCause cause = downstreamBuild2.getCause(Cause.UpstreamCause.class);
+        assertNotNull(cause);
+        assertEquals("intermediate #2", cause.getUpstreamRun().getFullDisplayName());
+
+        // Return artifacts from downstream#2. One of them was copied from 'upstream' that is
+        // - either the last successful upstream#2 build
+        // - or upstream#1, which is the same that the triggering intermediate#2 depends on
+        // depending on the value of allowUpstreamDependencies
+        String artifactFromUpstream = FileUtils.readFileToString(new File(downstreamBuild2.getArtifactsDir(), "upstream/artifact.txt"), "UTF-8");
+        String artifactFromIntermediate = FileUtils.readFileToString(new File(downstreamBuild2.getArtifactsDir(), "intermediate/artifact.txt"), "UTF-8");
+
+        return artifactFromIntermediate + "," + artifactFromUpstream;
+    }
+
+    @Test
+    public void testTryUpstreamBuildDisabled() throws Exception {
+        assertEquals("upstreamValue1,upstreamValue2", getDownstreamAfterOverlappingFlow(false));
+    }
+
+    @Test
+    public void testTryUpstreamBuildEnabled() throws Exception {
+        assertEquals("upstreamValue1,upstreamValue1", getDownstreamAfterOverlappingFlow(true));
+    }
+
     @Bug(18804)
     @Test
     public void testUpstreamWasRemoved() throws Exception {
@@ -648,7 +766,7 @@ public class TriggeredBuildSelectorTest {
             downstream.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(
                     upstream.getFullName(),
                     "",
-                    new TriggeredBuildSelector(false, TriggeredBuildSelector.UpstreamFilterStrategy.UseGlobalSetting),
+                    new TriggeredBuildSelector(false, TriggeredBuildSelector.UpstreamFilterStrategy.UseGlobalSetting, false),
                     "**/*",
                     "",
                     "",
@@ -697,7 +815,7 @@ public class TriggeredBuildSelectorTest {
             downstream.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(
                     upstream.getFullName(),
                     "",
-                    new TriggeredBuildSelector(false, TriggeredBuildSelector.UpstreamFilterStrategy.UseGlobalSetting),
+                    new TriggeredBuildSelector(false, TriggeredBuildSelector.UpstreamFilterStrategy.UseGlobalSetting, false),
                     "**/*",
                     "",
                     "",
@@ -747,7 +865,7 @@ public class TriggeredBuildSelectorTest {
             downstream.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(
                     upstream.getFullName(),
                     "",
-                    new TriggeredBuildSelector(false, TriggeredBuildSelector.UpstreamFilterStrategy.UseGlobalSetting),
+                    new TriggeredBuildSelector(false, TriggeredBuildSelector.UpstreamFilterStrategy.UseGlobalSetting, false),
                     "**/*",
                     "",
                     "",
@@ -781,7 +899,7 @@ public class TriggeredBuildSelectorTest {
         downstream.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(
                 String.format("%s/org.jvnet.hudson.main.test.multimod$moduleB", upstream.getName()),
                 "",
-                new TriggeredBuildSelector(false, null),
+                new TriggeredBuildSelector(false, null, false),
                 "**/*",
                 "",
                 "",


### PR DESCRIPTION
The CopyArtifact plugin with 'Upstream build that triggered this job' works fine for us for a chain of jobs when the build started with the first job that triggers the next one, which triggers the next, and so on. The advantage of the Upstream-build strategy is that it works even with overlapping chains of builds. But there is a problem when we have overlapping chains and the build is started with an intermediate job.

Let's consider a simple scenario: each job triggers the next one
ModuleA --> ModuleB --> Publisher
where 
ModuleB depends on artifacts of ModuleA (using the Upstream-build strategy),
Publisher copies artifacts from ModuleA and ModuleB (using the Upstream-build strategy),
ModuleB needs significantly more time to build than ModuleA, so ModuleA can build while a ModuleB build is running.

Example execution:
ModuleA#1 is triggered by SCM, builds successfully.
ModuleB#1 is triggered by ModuleA#1, copies its artifacts and builds successfully.
Publisher#1 is triggered by ModuleB#1, copies artifacts from ModuleA#1 and ModuleB#1.
ModuleB#2 is triggered by SCM, copies artifacts from ModuleA#1 (fallback to last successful), build started...
ModuleA#2 is triggered by SCM, builds successfully.
... ModuleB#2 finished.
Publisher#2 is triggered by ModuleB#2, copies artifacts from ModuleB#2 and ModuleA#2 (fallback) instead of ModuleA#1, which ModuleB#2 depends on.
ModuleB#3 and Publisher#3 works as expected.
    
This scenario happens more easily if the chain is longer and contains more than 3 jobs.
The problem here is the inconsistent builds (here the Publisher), or the violated isolation of build chains.

I hope what I've written so far is a reasonable issue.

What I found to this is that, the Upstream-build strategy in CopyArtifact plugin could include the upstream builds of the target build, not just the builds that triggered it. I have implemented this change introducing an additional checkbox for this, tried on a local Jenkins installation and seems working. 