### PR TITLE
[DO NOT MERGE] [JENKINS-20546] Tests symlinks with fingerprintArtifacts disabled.

### DIFF
--- a/src/test/java/hudson/plugins/copyartifact/CopyArtifactTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/CopyArtifactTest.java
@@ -1673,7 +1673,7 @@ public class CopyArtifactTest extends HudsonTestCase {
         p1.getPublishersList().add(new ArtifactArchiver("**", "", false, false));
         buildAndAssertSuccess(p1);
         FreeStyleProject p2 = createFreeStyleProject("p2");
-        p2.getBuildersList().add(CopyArtifactUtil.createCopyArtifact("p1", null, new StatusBuildSelector(true), null, "", false, false, true));
+        p2.getBuildersList().add(CopyArtifactUtil.createCopyArtifact("p1", null, new StatusBuildSelector(true), null, "", false, false, false));
         FreeStyleBuild b = buildAndAssertSuccess(p2);
         FilePath ws = b.getWorkspace();
         assertEquals("text", ws.child("plain").readToString());


### PR DESCRIPTION
To test the reproduction of the following post:
[JENKINS-20546 Preserve symlinks when copying artifacts](https://issues.jenkins-ci.org/browse/JENKINS-20546?focusedCommentId=240686&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-240686)
```
This is still broken in 1.36.1 if fingerprinting of artifacts is not enabled.
```

As far as I know, `fingerprintArtifacts` never affect handling symlinks and I don't plan to merge this change.