### PR TITLE
Do not allow httpclient/httpcore from maven-plugin to override jenkins-test-harness deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,14 @@
             <groupId>org.jenkins-ci</groupId>
             <artifactId>SECURITY-144-compat</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <!-- Used for UI test -->


### PR DESCRIPTION
When run against 1.625.2, `DownstreamBuildSelectorTest.testConfiguration` fails with a JS NPE inside `confirm.js`

```javascript
if (btn.parentNode.parentNode.classList.contains("advanced-button")) {
```

Seems to be a regression from https://github.com/jenkinsci/jenkins/pull/1854 but only when using the old forked HtmlUnit.

This patch just ensures that we pick up some test-scope classes from the test harness, not the Maven plugin, so that we *can* run against a newer test harness (which then passes).

@reviewbybees esp. @kwhetstone