### PR TITLE
Do not allow httpclient/httpcore from maven-plugin to override jenkins-test-harness deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,14 @@
             <groupId>org.jenkins-ci</groupId>
             <artifactId>SECURITY-144-compat</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <!-- Used for UI test -->

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,10 @@
             <groupId>org.jenkins-ci</groupId>
             <artifactId>SECURITY-144-compat</artifactId>
           </exclusion>
+          <!--
+              To pick up http component classes from jenkins-test-harness dependencies
+              in test executions.
+          -->
           <exclusion>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>


### PR DESCRIPTION
Added a comment for #76 ,dependency exclusions in pom.xml.