### PR TITLE
[JENKINS-33389] Adapt to new parent POM and split JTH

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.3</version>
+        <version>2.5</version>
     </parent>
 
     <artifactId>copyartifact</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.580.1</version>
+        <version>2.3</version>
     </parent>
 
     <artifactId>copyartifact</artifactId>
@@ -22,7 +22,9 @@
     </licenses>
 
     <properties>
-        <workflow.version>1.1</workflow.version>
+      <jenkins.version>1.580.1</jenkins.version>
+      <java.level>6</java.level>
+      <workflow.version>1.1</workflow.version>
     </properties>
 
     <dependencies>
@@ -53,6 +55,12 @@
       </dependency>
       <!-- Used for UI test -->
       <dependency>
+        <groupId>org.jenkins-ci.main</groupId>
+        <artifactId>jenkins-test-harness-tools</artifactId>
+        <version>2.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>cloudbees-folder</artifactId>
         <version>4.0</version>
@@ -62,6 +70,24 @@
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>matrix-project</artifactId>
         <version>1.3</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>junit</artifactId>
+        <version>1.10</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>credentials</artifactId>
+        <version>1.24</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>matrix-auth</artifactId>
+        <version>1.2</version>
+        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -99,31 +125,7 @@
             </exclusion>
         </exclusions>
       </dependency>
-      <!-- to suppress known (and harmless) findbugs issues -->
-      <dependency>
-          <groupId>com.google.code.findbugs</groupId>
-          <artifactId>annotations</artifactId>
-          <version>3.0.0</version>
-      </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.jenkins-ci.tools</groupId>
-                <artifactId>maven-hpi-plugin</artifactId>
-                <version>1.95</version>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.1</version>
-                <configuration>
-                    <xmlOutput>true</xmlOutput>
-                    <failOnError>false</failOnError>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
     <reporting>
       <plugins>
         <plugin>
@@ -147,19 +149,20 @@
       <tag>HEAD</tag>
   </scm>
 
-    <repositories>
-        <repository>
-            <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
-        </repository>
-    </repositories>
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>http://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
 
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
-        </pluginRepository>
-    </pluginRepositories>
-</project>  
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>http://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
+</project>
   
 

--- a/src/main/java/hudson/plugins/copyartifact/BuildSelector.java
+++ b/src/main/java/hudson/plugins/copyartifact/BuildSelector.java
@@ -67,7 +67,11 @@ public abstract class BuildSelector extends AbstractDescribableImpl<BuildSelecto
     }
 
     /**
-     * Older version of API.
+     * Find a build to copy artifacts from. Older and deprecated version of API.
+     * @param job Source project
+     * @param env Environment for build that is copying artifacts
+     * @param filter Additional filter; returned result should return true (return null otherwise)
+     * @return Build to use, or null if no appropriate build was found
      */
     @Deprecated
     public Run<?,?> getBuild(Job<?,?> job, EnvVars env, BuildFilter filter) {
@@ -91,9 +95,10 @@ public abstract class BuildSelector extends AbstractDescribableImpl<BuildSelecto
      * Returns <code>false</code> if <code>run</code> is <code>null</code>
      * or <code>run</code> is still running.
      * 
-     * @param run
-     * @param resultToTest
-     * @return
+     * @param run Build to test.
+     * @param resultToTest Result to test.
+     * @return <code>false</code> if <code>run</code> is <code>null</code>
+     * or <code>run</code> is still running.
      * @see Result#isBetterOrEqualTo(Result)
      */
     protected static boolean isBuildResultBetterOrEqualTo(Run<?,?> run, Result resultToTest) {

--- a/src/main/java/hudson/plugins/copyartifact/BuildSelectorParameter.java
+++ b/src/main/java/hudson/plugins/copyartifact/BuildSelectorParameter.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
 
+import com.thoughtworks.xstream.XStreamException;
 import jenkins.model.Jenkins;
 import hudson.DescriptorExtensionList;
 import hudson.Extension;
@@ -84,7 +85,10 @@ public class BuildSelectorParameter extends SimpleParameterDefinition {
 
     /**
      * Convert xml fragment into a BuildSelector object.
-     * @throws XStreamException or ClassCastException if input is invalid
+     * @param xml XML fragment to parse.
+     * @return the BuildSelector represented by the input XML.
+     * @throws XStreamException if the object cannot be deserialized
+     * @throws ClassCastException if input is invalid
      */
     public static BuildSelector getSelectorFromXml(String xml) {
         return (BuildSelector)XSTREAM.fromXML(xml);

--- a/src/main/java/hudson/plugins/copyartifact/Copier.java
+++ b/src/main/java/hudson/plugins/copyartifact/Copier.java
@@ -37,6 +37,8 @@ public abstract class Copier implements ExtensionPoint {
      * @param baseTargetDir Base target dir for upcoming file copy (the copy-artifact
      *   build step may later specify a deeper target dir)
      *
+     * @throws IOException if an error occurs while performing the operation.
+     * @throws InterruptedException if any thread interrupts the current thread.
      * @since TODO ?
      */
     public void initialize(Run<?, ?> src, Run<?, ?> dst, FilePath srcDir, FilePath baseTargetDir) throws IOException, InterruptedException {
@@ -50,6 +52,18 @@ public abstract class Copier implements ExtensionPoint {
     }
 
     /**
+     * Called before copy-artifact operation.
+     *
+     * @param src
+     *      The build record from which we are copying artifacts.
+     * @param dst
+     *      The built into which we are copying artifacts.
+     * @param srcDir Source for upcoming file copy
+     * @param baseTargetDir Base target dir for upcoming file copy (the copy-artifact
+     *   build step may later specify a deeper target dir)
+     *
+     * @throws IOException if an error occurs while performing the operation.
+     * @throws InterruptedException if any thread interrupts the current thread.
      * @deprecated Please use {@link #initialize(hudson.model.Run, hudson.model.Run, hudson.FilePath, hudson.FilePath)}
      */
     @Deprecated
@@ -66,15 +80,33 @@ public abstract class Copier implements ExtensionPoint {
     }
 
     /**
-     * @deprecated 
+     * Copy files matching the given file mask to the specified target.
+     *
+     * @param srcDir Source directory
+     * @param filter Ant GLOB pattern
+     * @param targetDir Target directory
+     * @return Number of files that were copied
+     * @throws IOException if an error occurs while performing the operation.
+     * @throws InterruptedException if any thread interrupts the current thread.
+     * @deprecated
      *      call/override {@link #copyAll(FilePath srcDir, String filter, String excludes, FilePath targetDir, boolean fingerprintArtifacts)} instead.
      */
+    @Deprecated
     public int copyAll(FilePath srcDir, String filter, FilePath targetDir) throws IOException, InterruptedException {
         return copyAll(srcDir, filter, null, targetDir, true);
     }
 
     /**
-     * @deprecated 
+     * Copy files matching the given file mask to the specified target.
+     *
+     * @param srcDir Source directory
+     * @param filter Ant GLOB pattern
+     * @param targetDir Target directory
+     * @param fingerprintArtifacts boolean controlling if the copy should also fingerprint the artifacts
+     * @return Number of files that were copied
+     * @throws IOException if an error occurs while performing the operation.
+     * @throws InterruptedException if any thread interrupts the current thread.
+     * @deprecated
      *      call/override {@link #copyAll(FilePath, String, String, FilePath, boolean)} instead.
      */
     @Deprecated
@@ -92,6 +124,8 @@ public abstract class Copier implements ExtensionPoint {
      * @param excludes Ant GLOB pattern. Can be null.
      * @param targetDir Target directory
      * @param fingerprintArtifacts boolean controlling if the copy should also fingerprint the artifacts
+     * @throws IOException if an error occurs while performing the operation.
+     * @throws InterruptedException if any thread interrupts the current thread.
      * @return Number of files that were copied
      * @see FilePath#copyRecursiveTo(String,FilePath)
      */
@@ -112,9 +146,16 @@ public abstract class Copier implements ExtensionPoint {
     }
     
     /**
-     * @deprecated 
+     * Copy a single file.
+     * @param source Source file
+     * @param target Target file (includes filename; this is not the target directory).
+     *   Directory for target should already exist (copy-artifact build step calls mkdirs).
+     * @throws IOException if an error occurs while performing the operation.
+     * @throws InterruptedException if any thread interrupts the current thread.
+     * @deprecated
      *      call/override {@link #copyOne(FilePath source, FilePath target, boolean fingerprintArtifacts)} instead.
      */
+    @Deprecated
     public void copyOne(FilePath source, FilePath target) throws IOException, InterruptedException {
         copyOne(source, target, true);
     }
@@ -125,12 +166,15 @@ public abstract class Copier implements ExtensionPoint {
      * @param target Target file (includes filename; this is not the target directory).
      *   Directory for target should already exist (copy-artifact build step calls mkdirs).
      * @param fingerprintArtifacts boolean controlling if the copy should also fingerprint the artifacts
+     * @throws IOException if an error occurs while performing the operation.
+     * @throws InterruptedException if any thread interrupts the current thread.
      * @see FilePath#copyTo(FilePath)
      */
     public abstract void copyOne(FilePath source, FilePath target, boolean fingerprintArtifacts) throws IOException, InterruptedException;
 
     /**
      * Ends what's started by the {@link #init(Run, AbstractBuild, FilePath, FilePath)} method.
+     * @throws IOException if an error occurs while performing the operation.
      */
     public void end() throws IOException, InternalError {}
 

--- a/src/main/java/hudson/plugins/copyartifact/CopyArtifact.java
+++ b/src/main/java/hudson/plugins/copyartifact/CopyArtifact.java
@@ -203,7 +203,7 @@ public class CopyArtifact extends Builder implements SimpleBuildStep {
     /**
      * Set the suffix for variables to store copying results.
      * 
-     * @param resultVariableSuffix
+     * @param resultVariableSuffix Variable suffix to use.
      */
     @DataBoundSetter
     public void setResultVariableSuffix(String resultVariableSuffix) {

--- a/src/main/java/hudson/plugins/copyartifact/CopyArtifactPermissionProperty.java
+++ b/src/main/java/hudson/plugins/copyartifact/CopyArtifactPermissionProperty.java
@@ -169,10 +169,11 @@ public class CopyArtifactPermissionProperty extends JobProperty<AbstractProject<
         }
         
         /**
-         * @param req
-         * @param formData
-         * @return
-         * @throws hudson.model.Descriptor.FormException
+         * Creates a new property.
+         * @param req Request.
+         * @param formData Form data.
+         * @return The created property.
+         * @throws hudson.model.Descriptor.FormException If an error occurs parsing the form data.
          * @see hudson.model.JobPropertyDescriptor#newInstance(org.kohsuke.stapler.StaplerRequest, net.sf.json.JSONObject)
          */
         @Override
@@ -222,8 +223,10 @@ public class CopyArtifactPermissionProperty extends JobProperty<AbstractProject<
         }
         
         /**
-         * @param projectNames
-         * @return
+         * Checks the provided projects exist in the provided context.
+         * @param projectNames Projects to check.
+         * @param context Context.
+         * @return ok if all projects are found and a warning otherwise.
          */
         public FormValidation doCheckProjectNames(@QueryParameter String projectNames, @AncestorInPath ItemGroup<?> context) {
             List<String> notFound = checkNotFoundProjects(projectNames, context);
@@ -234,9 +237,10 @@ public class CopyArtifactPermissionProperty extends JobProperty<AbstractProject<
         }
         
         /**
-         * @param value
-         * @param context
-         * @return
+         * Provides candidates for project name autocompletion.
+         * @param value Seed value.
+         * @param context Context.
+         * @return The proposed project candidates.
          */
         public AutoCompletionCandidates doAutoCompleteProjectNames(@QueryParameter String value, @AncestorInPath ItemGroup<?> context) {
             AutoCompletionCandidates candidates = new AutoCompletionCandidates();

--- a/src/main/java/hudson/plugins/copyartifact/DownstreamBuildSelector.java
+++ b/src/main/java/hudson/plugins/copyartifact/DownstreamBuildSelector.java
@@ -55,8 +55,9 @@ public class DownstreamBuildSelector extends BuildSelector {
     private final String upstreamBuildNumber;
     
     /**
-     * @param upstreamProjectName
-     * @param upstreamBuildNumber
+     * Constructor.
+     * @param upstreamProjectName Upstream project name.
+     * @param upstreamBuildNumber Upstream build number.
      */
     @DataBoundConstructor
     public DownstreamBuildSelector(String upstreamProjectName, String upstreamBuildNumber) {
@@ -164,7 +165,7 @@ public class DownstreamBuildSelector extends BuildSelector {
         }
         
         /**
-         * @param str
+         * @param str Value to check.
          * @return whether a value contains variable expressions.
          */
         protected boolean containsVariable(String str) {
@@ -173,8 +174,10 @@ public class DownstreamBuildSelector extends BuildSelector {
         
         /**
          * Validates a form input to "Upstream Project Name"
-         * 
-         * @return
+         *
+         * @param project Ancestor project.
+         * @param upstreamProjectName Upstream project name.
+         * @return the form validation result.
          */
         public FormValidation doCheckUpstreamProjectName(
                 @AncestorInPath AbstractProject<?,?> project,
@@ -206,8 +209,11 @@ public class DownstreamBuildSelector extends BuildSelector {
         
         /**
          * Validates a form input to "Upstream Build Number"
-         * 
-         * @return
+         *
+         * @param project Ancestor project.
+         * @param upstreamProjectName Upstream project name.
+         * @param upstreamBuildNumber Upstream build number.
+         * @return the form validation result.
          */
         public FormValidation doCheckUpstreamBuildNumber(
                 @AncestorInPath AbstractProject<?,?> project,
@@ -283,9 +289,9 @@ public class DownstreamBuildSelector extends BuildSelector {
         /**
          * Fill the project name automatically.
          * 
-         * @param value
-         * @param project
-         * @return
+         * @param value Seed value.
+         * @param project Ancestor project.
+         * @return the autocompletion candidates.
          */
         public AutoCompletionCandidates doAutoCompleteUpstreamProjectName(
                 @QueryParameter String value,

--- a/src/main/java/hudson/plugins/copyartifact/FilePathCopyMethod.java
+++ b/src/main/java/hudson/plugins/copyartifact/FilePathCopyMethod.java
@@ -39,7 +39,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  */
 @Extension(ordinal=-200)
 public class FilePathCopyMethod extends Copier {
-    /** @see FilePath#recursiveCopyTo(String,FilePath) */
+    /** @see FilePath#copyRecursiveTo(String,FilePath) */
     @Override
     public int copyAll(FilePath srcDir, String filter, String excludes, FilePath targetDir, boolean fingerprintArtifacts)
             throws IOException, InterruptedException {

--- a/src/main/java/hudson/plugins/copyartifact/SimpleBuildSelectorDescriptor.java
+++ b/src/main/java/hudson/plugins/copyartifact/SimpleBuildSelectorDescriptor.java
@@ -29,8 +29,8 @@ import org.jvnet.localizer.Localizable;
 
 /**
  * Descriptor type for common case where no overrides are needed.
- * Just do: @Extension public static final Descriptor<BuildSelector> DESCRIPTOR =
- *          new SimpleBuildSelectorDescriptor(MySelector.class, Messages._My_DisplayName());
+ * Just do: {@code @Extension public static final Descriptor<BuildSelector> DESCRIPTOR =
+ *          new SimpleBuildSelectorDescriptor(MySelector.class, Messages._My_DisplayName()); }
  * @author Alan Harder
  */
 public class SimpleBuildSelectorDescriptor extends Descriptor<BuildSelector> {

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
   Adds a build step to copy artifacts from another project.
 </div>

--- a/src/test/java/hudson/plugins/copyartifact/BuildSelectorParameterTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/BuildSelectorParameterTest.java
@@ -24,15 +24,16 @@
 package hudson.plugins.copyartifact;
 
 import com.gargoylesoftware.htmlunit.HttpMethod;
-import com.gargoylesoftware.htmlunit.WebRequestSettings;
+import com.gargoylesoftware.htmlunit.WebClientOptions;
+import com.gargoylesoftware.htmlunit.WebRequest;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.util.NameValuePair;
 import hudson.cli.CLI;
 import hudson.model.FreeStyleProject;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Queue;
 import java.net.URL;
 import java.util.Arrays;
-import org.apache.commons.httpclient.NameValuePair;
 import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
 import org.jvnet.hudson.test.HudsonTestCase;
 
@@ -54,11 +55,13 @@ public class BuildSelectorParameterTest extends HudsonTestCase {
 
         // Run via UI (HTML form)
         WebClient wc = new WebClient();
+        WebClientOptions wco = wc.getOptions();
         // Jenkins sends 405 response for GET of build page.. deal with that:
-        wc.setThrowExceptionOnFailingStatusCode(false);
-        wc.setPrintContentOnFailingStatusCode(false);
+        wco.setThrowExceptionOnFailingStatusCode(false);
+        wco.setPrintContentOnFailingStatusCode(false);
         HtmlForm form = wc.getPage(job, "build").getFormByName("parameters");
         form.getSelectByName("").getOptionByText("Specific build").setSelected(true);
+        wc.waitForBackgroundJavaScript(10000);
         form.getInputByName("_.buildNumber").setValueAttribute("6");
         submit(form);
         Queue.Item q = hudson.getQueue().getItem(job);
@@ -69,7 +72,7 @@ public class BuildSelectorParameterTest extends HudsonTestCase {
         job.getBuildersList().replace(ceb = new CaptureEnvironmentBuilder());
 
         // Run via HTTP POST (buildWithParameters)
-        WebRequestSettings post = new WebRequestSettings(
+        WebRequest post = new WebRequest(
                 new URL(getURL(), job.getUrl()+"/buildWithParameters"), HttpMethod.POST);
         wc.addCrumb(post);
         String xml = "<StatusBuildSelector><stable>true</stable></StatusBuildSelector>";

--- a/src/test/java/hudson/plugins/copyartifact/BuildSelectorParameterTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/BuildSelectorParameterTest.java
@@ -34,27 +34,36 @@ import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Queue;
 import java.net.URL;
 import java.util.Arrays;
+
+import org.junit.Rule;
+import org.junit.Test;
 import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.JenkinsRule.WebClient;
+
+import static org.junit.Assert.*;
 
 /**
  * Test interaction of BuildSelectorParameter with Jenkins core.
  * @author Alan Harder
  */
-public class BuildSelectorParameterTest extends HudsonTestCase {
+public class BuildSelectorParameterTest {
+    @Rule
+    public final JenkinsRule rule = new JenkinsRule();
 
     /**
      * Verify BuildSelectorParameter works via HTML form, http POST and CLI.
      */
+    @Test
     public void testParameter() throws Exception {
-        FreeStyleProject job = createFreeStyleProject();
+        FreeStyleProject job = rule.createFreeStyleProject();
         job.addProperty(new ParametersDefinitionProperty(
                 new BuildSelectorParameter("SELECTOR", new StatusBuildSelector(false), "foo")));
         CaptureEnvironmentBuilder ceb = new CaptureEnvironmentBuilder();
         job.getBuildersList().add(ceb);
 
         // Run via UI (HTML form)
-        WebClient wc = new WebClient();
+        WebClient wc = rule.createWebClient();
         WebClientOptions wco = wc.getOptions();
         // Jenkins sends 405 response for GET of build page.. deal with that:
         wco.setThrowExceptionOnFailingStatusCode(false);
@@ -63,8 +72,8 @@ public class BuildSelectorParameterTest extends HudsonTestCase {
         form.getSelectByName("").getOptionByText("Specific build").setSelected(true);
         wc.waitForBackgroundJavaScript(10000);
         form.getInputByName("_.buildNumber").setValueAttribute("6");
-        submit(form);
-        Queue.Item q = hudson.getQueue().getItem(job);
+        rule.submit(form);
+        Queue.Item q = rule.jenkins.getQueue().getItem(job);
         if (q != null) q.getFuture().get();
         while (job.getLastBuild().isBuilding()) Thread.sleep(100);
         assertEquals("<SpecificBuildSelector><buildNumber>6</buildNumber></SpecificBuildSelector>",
@@ -73,36 +82,37 @@ public class BuildSelectorParameterTest extends HudsonTestCase {
 
         // Run via HTTP POST (buildWithParameters)
         WebRequest post = new WebRequest(
-                new URL(getURL(), job.getUrl()+"/buildWithParameters"), HttpMethod.POST);
+                new URL(rule.getURL(), job.getUrl()+"/buildWithParameters"), HttpMethod.POST);
         wc.addCrumb(post);
         String xml = "<StatusBuildSelector><stable>true</stable></StatusBuildSelector>";
         post.setRequestParameters(Arrays.asList(new NameValuePair("SELECTOR", xml),
                                                 post.getRequestParameters().get(0)));
         wc.getPage(post);
-        q = hudson.getQueue().getItem(job);
+        q = rule.jenkins.getQueue().getItem(job);
         if (q != null) q.getFuture().get();
         while (job.getLastBuild().isBuilding()) Thread.sleep(100);
         assertEquals(xml, ceb.getEnvVars().get("SELECTOR"));
         job.getBuildersList().replace(ceb = new CaptureEnvironmentBuilder());
 
         // Run via CLI
-        CLI cli = new CLI(getURL());
+        CLI cli = new CLI(rule.getURL());
         assertEquals(0, cli.execute(
                 "build", job.getFullName(), "-p", "SELECTOR=<SavedBuildSelector/>"));
-        q = hudson.getQueue().getItem(job);
+        q = rule.jenkins.getQueue().getItem(job);
         if (q != null) q.getFuture().get();
         while (job.getLastBuild().isBuilding()) Thread.sleep(100);
         assertEquals("<SavedBuildSelector/>", ceb.getEnvVars().get("SELECTOR"));
     }
     
+    @Test
     public void testConfiguration() throws Exception {
         BuildSelectorParameter expected = new BuildSelectorParameter("SELECTOR", new StatusBuildSelector(true), "foo");
-        FreeStyleProject job = createFreeStyleProject();
+        FreeStyleProject job = rule.createFreeStyleProject();
         job.addProperty(new ParametersDefinitionProperty(expected));
         job.save();
         
-        job = configRoundtrip(job);
+        job = rule.configRoundtrip(job);
         BuildSelectorParameter actual = (BuildSelectorParameter)job.getProperty(ParametersDefinitionProperty.class).getParameterDefinition("SELECTOR");
-        assertEqualDataBoundBeans(expected, actual);
+        rule.assertEqualDataBoundBeans(expected, actual);
     }
 }

--- a/src/test/java/hudson/plugins/copyartifact/CopyArtifactPermissionPropertyTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/CopyArtifactPermissionPropertyTest.java
@@ -32,6 +32,7 @@ import hudson.matrix.MatrixProject;
 import hudson.matrix.TextAxis;
 import hudson.model.FreeStyleProject;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -228,7 +229,7 @@ public class CopyArtifactPermissionPropertyTest {
                 = (CopyArtifactPermissionProperty.DescriptorImpl)j.jenkins.getDescriptor(CopyArtifactPermissionProperty.class);
         j.createFreeStyleProject("project1");
         j.createFreeStyleProject("project2");
-        MatrixProject matrix = j.createMatrixProject("matrix1");
+        MatrixProject matrix = createMatrixProject("matrix1");
         AxisList axes = new AxisList(new TextAxis("axis1", "value1"));
         matrix.setAxes(axes);
         MatrixConfiguration matrixConf = matrix.getItem(new Combination(axes, "value1"));
@@ -253,7 +254,7 @@ public class CopyArtifactPermissionPropertyTest {
         CopyArtifactPermissionProperty.DescriptorImpl d
                 = (CopyArtifactPermissionProperty.DescriptorImpl)j.jenkins.getDescriptor(CopyArtifactPermissionProperty.class);
         j.createFreeStyleProject("project1");
-        MatrixProject matrix = j.createMatrixProject("matrix1");
+        MatrixProject matrix = createMatrixProject("matrix1");
         AxisList axes = new AxisList(new TextAxis("axis1", "value1"));
         matrix.setAxes(axes);
         
@@ -269,4 +270,15 @@ public class CopyArtifactPermissionPropertyTest {
         assertEquals(Collections.emptyList(), d.doAutoCompleteProjectNames("x", j.jenkins).getValues());
         assertEquals(Collections.emptyList(), d.doAutoCompleteProjectNames("", j.jenkins).getValues());
     }
+
+    /**
+     * Creates an empty Matrix project with the provided name.
+     *
+     * @param name Project name.
+     * @return an empty Matrix project with the provided name.
+     */
+    private MatrixProject createMatrixProject(String name) throws IOException {
+        return j.jenkins.createProject(MatrixProject.class, name);
+    }
+
 }

--- a/src/test/java/hudson/plugins/copyartifact/CopyArtifactTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/CopyArtifactTest.java
@@ -80,6 +80,7 @@ import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
 import org.jvnet.hudson.test.FailureBuilder;
 import org.jvnet.hudson.test.MockFolder;
+import org.jvnet.hudson.test.ToolInstallations;
 import org.jvnet.hudson.test.UnstableBuilder;
 import org.jvnet.hudson.test.recipes.LocalData;
 import org.jvnet.hudson.test.recipes.WithPlugin;
@@ -182,6 +183,27 @@ public class CopyArtifactTest extends HudsonTestCase {
     private FreeStyleProject createArtifactProject() throws IOException {
         return createArtifactProject(null);
     }
+
+    /**
+     * Creates an empty Maven project with an unique name.
+     *
+     * @return an empty Maven project with an unique name.
+     */
+    private MavenModuleSet createMavenProject() throws IOException {
+        MavenModuleSet mavenModuleSet = jenkins.createProject(MavenModuleSet.class, createUniqueProjectName());
+        mavenModuleSet.setRunHeadless(true);
+        return mavenModuleSet;
+    }
+
+    /**
+     * Creates an empty Matrix project with an unique name.
+     *
+     * @return an empty Matrix project with an unique name.
+     */
+    private MatrixProject createMatrixProject() throws IOException {
+        return jenkins.createProject(MatrixProject.class, createUniqueProjectName());
+    }
+
 
     private MatrixProject createMatrixArtifactProject() throws IOException {
         MatrixProject p = createMatrixProject();
@@ -377,7 +399,7 @@ public class CopyArtifactTest extends HudsonTestCase {
     }
 
     private MavenModuleSet setupMavenJob() throws Exception {
-        configureDefaultMaven();
+        ToolInstallations.configureDefaultMaven();
         MavenModuleSet mp = createMavenProject();
         mp.setGoals("clean package");
         mp.setScm(new ExtractResourceSCM(getClass().getResource("maven-job.zip")));

--- a/src/test/java/hudson/plugins/copyartifact/CopyArtifactTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/CopyArtifactTest.java
@@ -72,13 +72,16 @@ import jenkins.security.QueueItemAuthenticatorConfiguration;
 import org.acegisecurity.context.SecurityContext;
 import org.acegisecurity.context.SecurityContextHolder;
 import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
+import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.Bug;
+import org.junit.rules.TestName;
 import org.jvnet.hudson.test.ExtractResourceSCM;
-import org.jvnet.hudson.test.HudsonTestCase;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
 import org.jvnet.hudson.test.FailureBuilder;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import org.jvnet.hudson.test.MockFolder;
 import org.jvnet.hudson.test.ToolInstallations;
 import org.jvnet.hudson.test.UnstableBuilder;
@@ -91,17 +94,25 @@ import com.google.common.collect.Sets;
 
 import org.jvnet.hudson.test.TestBuilder;
 
+import static org.junit.Assert.*;
+
 /**
  * Test interaction of copyartifact plugin with Jenkins core.
  * @author Alan Harder
  */
-public class CopyArtifactTest extends HudsonTestCase {
+public class CopyArtifactTest {
+    @Rule
+    public final JenkinsRule rule = new JenkinsRule();
+
+    @Rule
+    public TestName name = new TestName();
+
     // Tests using slaves fails with Jenkins < 1.520 on Windows.
     // See https://wiki.jenkins-ci.org/display/JENKINS/Unit+Test+on+Windows
     private void purgeSlaves() {
         List<Computer> disconnectingComputers = new ArrayList<Computer>();
         List<VirtualChannel> closingChannels = new ArrayList<VirtualChannel>();
-        for (Computer computer: jenkins.getComputers()) {
+        for (Computer computer: rule.jenkins.getComputers()) {
             if (!(computer instanceof SlaveComputer)) {
                 continue;
             }
@@ -129,18 +140,17 @@ public class CopyArtifactTest extends HudsonTestCase {
         }
     }
     
-    @Override
-    protected void tearDown() throws Exception {
+    @After
+    public void tearDown() throws Exception {
         if(Functions.isWindows()) {
             purgeSlaves();
         }
-        super.tearDown();
     }
 
     private FreeStyleProject createProject(String otherProject, String parameters, String filter,
             String target, boolean stable, boolean flatten, boolean optional, boolean fingerprintArtifacts)
             throws IOException {
-        FreeStyleProject p = createFreeStyleProject();
+        FreeStyleProject p = rule.createFreeStyleProject();
         CopyArtifact copyArtifact = CopyArtifactUtil.createCopyArtifact(otherProject, parameters, new StatusBuildSelector(stable), filter, target, flatten, optional, fingerprintArtifacts);
         p.getBuildersList().add(copyArtifact);
         return p;
@@ -174,7 +184,7 @@ public class CopyArtifactTest extends HudsonTestCase {
     }
 
     private FreeStyleProject createArtifactProject(String name) throws IOException {
-        FreeStyleProject p = name != null ? createFreeStyleProject(name) : createFreeStyleProject();
+        FreeStyleProject p = name != null ? rule.createFreeStyleProject(name) : rule.createFreeStyleProject();
         p.getBuildersList().add(new ArtifactBuilder());
         p.getPublishersList().add(new ArtifactArchiver("**", "", false, false));
         return p;
@@ -184,13 +194,17 @@ public class CopyArtifactTest extends HudsonTestCase {
         return createArtifactProject(null);
     }
 
+    private String createUniqueProjectName() {
+        return "test" + rule.jenkins.getItems().size();
+    }
+
     /**
      * Creates an empty Maven project with an unique name.
      *
      * @return an empty Maven project with an unique name.
      */
     private MavenModuleSet createMavenProject() throws IOException {
-        MavenModuleSet mavenModuleSet = jenkins.createProject(MavenModuleSet.class, createUniqueProjectName());
+        MavenModuleSet mavenModuleSet = rule.jenkins.createProject(MavenModuleSet.class, createUniqueProjectName());
         mavenModuleSet.setRunHeadless(true);
         return mavenModuleSet;
     }
@@ -201,7 +215,7 @@ public class CopyArtifactTest extends HudsonTestCase {
      * @return an empty Matrix project with an unique name.
      */
     private MatrixProject createMatrixProject() throws IOException {
-        return jenkins.createProject(MatrixProject.class, createUniqueProjectName());
+        return rule.jenkins.createProject(MatrixProject.class, createUniqueProjectName());
     }
 
 
@@ -213,45 +227,50 @@ public class CopyArtifactTest extends HudsonTestCase {
         return p;
     }
 
-    private static void assertFile(boolean exists, String path, AbstractBuild<?,?> b)
+    private void assertFile(boolean exists, String path, AbstractBuild<?,?> b)
             throws IOException, InterruptedException {
         if (b.getWorkspace().child(path).exists() != exists)
-            assertEquals(path + ": " + getLog(b), exists, !exists);
+            assertEquals(path + ": " + rule.getLog(b), exists, !exists);
     }
 
+    @Test
     public void testMissingProject() throws Exception {
         FreeStyleProject p = createProject("invalid", null, "", "", false, false, false, true);
-        assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0, new UserCause()).get());
     }
 
+    @Test
     public void testMissingBuild() throws Exception {
-        FreeStyleProject other = createFreeStyleProject(),
+        FreeStyleProject other = rule.createFreeStyleProject(),
                          p = createProject(other.getName(), null, "", "", false, false, false, true);
-        assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0, new UserCause()).get());
     }
 
+    @Test
     public void testMissingStableBuild() throws Exception {
-        FreeStyleProject other = createFreeStyleProject(),
+        FreeStyleProject other = rule.createFreeStyleProject(),
                          p = createProject(other.getName(), null, "", "", true, false, false, true);
         // Make an unstable build in "other"
         other.getBuildersList().add(new UnstableBuilder());
-        assertBuildStatus(Result.UNSTABLE, other.scheduleBuild2(0, new UserCause()).get());
-        assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatus(Result.UNSTABLE, other.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0, new UserCause()).get());
     }
 
+    @Test
     public void testMissingArtifact() throws Exception {
-        FreeStyleProject other = createFreeStyleProject(),
+        FreeStyleProject other = rule.createFreeStyleProject(),
                          p = createProject(other.getName(), null, "*.txt", "", false, false, false, true);
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
-        assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0, new UserCause()).get());
     }
 
+    @Test
     public void testCopyAllWithFingerprints() throws Exception {
         FreeStyleProject other = createArtifactProject(),
                          p = createProject(other.getName(), null, "", "", false, false, false, true);
-        FreeStyleBuild s = assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
+        FreeStyleBuild s = rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertFile(true, "foo.txt", b);
         assertFile(true, "subdir/subfoo.txt", b);
         assertFile(true, "deepfoo/a/b/c.log", b);
@@ -263,12 +282,13 @@ public class CopyArtifactTest extends HudsonTestCase {
         assertTrue(f.getRangeSet(p).includes(b.getNumber()));
     }
 
+    @Test
     public void testCopyAllWithoutFingerprints() throws Exception {
         FreeStyleProject other = createArtifactProject(),
                          p = createProject(other.getName(), null, "", "", false, false, false, false);
-        FreeStyleBuild s = assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
+        FreeStyleBuild s = rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertFile(true, "foo.txt", b);
         assertFile(true, "subdir/subfoo.txt", b);
         assertFile(true, "deepfoo/a/b/c.log", b);
@@ -278,70 +298,75 @@ public class CopyArtifactTest extends HudsonTestCase {
         assertNull(Hudson.getInstance().getFingerprintMap().get(d));
     }
 
+    @Test
     public void testCopyWithFilter() throws Exception {
         FreeStyleProject other = createArtifactProject(),
                  p = createProject(other.getName(), null, "**/bogus*, **/sub*, bogus/**", "",
                                    false, false, false, true);
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertFile(false, "foo.txt", b);
         assertFile(true, "subdir/subfoo.txt", b);
         assertFile(false, "deepfoo/a/b/c.log", b);
     }
 
+    @Test
     public void testCopyToTarget() throws Exception {
         FreeStyleProject other = createArtifactProject(),
                  p = createProject(other.getName(), null, "deep*/**", "new/deep/dir",
                                    true, false, false, true);
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertFile(false, "foo.txt", b);
         assertFile(false, "new/deep/dir/foo.txt", b);
         assertFile(true, "new/deep/dir/deepfoo/a/b/c.log", b);
     }
 
+    @Test
     public void testCopyToSlave() throws Exception {
-        DumbSlave node = createSlave();
+        DumbSlave node = rule.createSlave();
         SlaveComputer c = node.getComputer();
         c.connect(false).get(); // wait until it's connected
         if(c.isOffline())
             fail("Slave failed to go online: " + c.getLog());
         FreeStyleProject other = createArtifactProject(),
                          p = createProject(other.getName(), null, "", "", false, false, false, true);
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         p.setAssignedLabel(node.getSelfLabel());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertSame(node, b.getBuiltOn());
         assertFile(true, "foo.txt", b);
         assertFile(true, "subdir/subfoo.txt", b);
         assertFile(true, "deepfoo/a/b/c.log", b);
     }
 
+    @Test
     public void testParameters() throws Exception {
         FreeStyleProject other = createArtifactProject(),
                          p = createProject("$PROJSRC", null, "$BASE/*.txt", "$TARGET/bar",
                                            false, false, false, true);
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause(),
                 new ParametersAction(new StringParameterValue("PROJSRC", other.getName()),
                                      new StringParameterValue("BASE", "*r"),
                                      new StringParameterValue("TARGET", "foo"))).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertFile(false, "foo/bar/foo.txt", b);
         assertFile(true, "foo/bar/subdir/subfoo.txt", b);
     }
 
     /** Test copying artifacts from a particular configuration of a matrix job */
+    @Test
     public void testMatrixJob() throws Exception {
         MatrixProject other = createMatrixArtifactProject();
         FreeStyleProject p = createProject(other.getName() + "/FOO=two", null, "", "",
                                            true, false, false, true);
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertFile(true, "foo.txt", b);
         assertFile(true, "two.txt", b);
         assertFile(true, "subdir/subfoo.txt", b);
@@ -349,15 +374,16 @@ public class CopyArtifactTest extends HudsonTestCase {
     }
 
     /** Test artifact copy between matrix jobs, for artifact from matching axis */
+    @Test
     public void testMatrixToMatrix() throws Exception {
         MatrixProject other = createMatrixArtifactProject(),
                       p = createMatrixProject();
         p.setAxes(new AxisList(new Axis("FOO", "one", "two"))); // should match other job
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(other.getName() + "/FOO=$FOO", null,
                 new StatusBuildSelector(true), "", "", false, false, true));
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         MatrixBuild b = p.scheduleBuild2(0, new UserCause()).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         MatrixRun r = b.getRun(new Combination(Collections.singletonMap("FOO", "one")));
         assertFile(true, "one.txt", r);
         assertFile(false, "two.txt", r);
@@ -383,15 +409,16 @@ public class CopyArtifactTest extends HudsonTestCase {
     }
 
     /** Test copying artifacts from all configurations of a matrix job */
+    @Test
     public void testMatrixAll() throws Exception {
         MatrixProject mp = createMatrixProject();
         mp.setAxes(new AxisList(new Axis("ARCH", "sparc", "x86")));
         mp.getBuildersList().add(new ArchMatrixBuilder());
         mp.getPublishersList().add(new ArtifactArchiver("target/*", "", false, false));
-        assertBuildStatusSuccess(mp.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatusSuccess(mp.scheduleBuild2(0, new UserCause()).get());
         FreeStyleProject p = createProject(mp.getName(), null, "", "", true, false, false, true);
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertFile(true, "ARCH=sparc/target/readme.txt", b);
         assertFile(true, "ARCH=sparc/target/sparc.out", b);
         assertFile(true, "ARCH=x86/target/readme.txt", b);
@@ -415,9 +442,10 @@ public class CopyArtifactTest extends HudsonTestCase {
     }
 
     /** Test copying from a particular module of a maven job */
+    @Test
     public void testMavenJob() throws Exception {
         MavenModuleSet mp = setupMavenJob();
-        assertBuildStatusSuccess(mp.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatusSuccess(mp.scheduleBuild2(0, new UserCause()).get());
         FreeStyleProject p = createProject(mp.getName() + "/org.jvnet.hudson.main.test.multimod$moduleB",
                 null, "", "", true, false, false, true);
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
@@ -427,9 +455,10 @@ public class CopyArtifactTest extends HudsonTestCase {
     }
 
     /** Test copying all artifacts from a maven job */
+    @Test
     public void testMavenAll() throws Exception {
         MavenModuleSet mp = setupMavenJob();
-        assertBuildStatusSuccess(mp.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatusSuccess(mp.scheduleBuild2(0, new UserCause()).get());
         FreeStyleProject p = createProject(mp.getName(), null, "", "", true, false, false, true);
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
         String dir = "org.jvnet.hudson.main.test.multimod/";
@@ -451,13 +480,14 @@ public class CopyArtifactTest extends HudsonTestCase {
     }
 
     /** Test copying from maven job where artifacts manually archived instead of automatic */
+    @Test
     public void testMavenJobWithArchivePostBuildStep() throws Exception {
         MavenModuleSet mp = setupMavenJob();
         // Turn off automatic archiving and use a post-build step instead.
         // Artifacts will be stored with the parent build instead of the child module builds.
         mp.setIsArchivingDisabled(true);
         mp.getPublishersList().add(new ArtifactArchiver("moduleB/*.xml", "", false, false));
-        assertBuildStatusSuccess(mp.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatusSuccess(mp.scheduleBuild2(0, new UserCause()).get());
         FreeStyleProject p = createProject(mp.getName(), null, "", "", true, false, false, true);
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
         // Archived artifact should be copied:
@@ -473,74 +503,80 @@ public class CopyArtifactTest extends HudsonTestCase {
     }
 
     /** Test copy from workspace instead of artifacts area */
+    @Test
     public void testCopyFromWorkspace() throws Exception {
-        FreeStyleProject other = createFreeStyleProject(), p = createFreeStyleProject();
+        FreeStyleProject other = rule.createFreeStyleProject(), p = rule.createFreeStyleProject();
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(other.getName(), null, new WorkspaceSelector(),
                 "**/*.txt", "", true, false, true));
         // Run a build that places a file in the workspace, but does not archive anything
         other.getBuildersList().add(new ArtifactBuilder());
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertFile(true, "foo.txt", b);
         assertFile(true, "subfoo.txt", b);
         assertFile(false, "c.log", b);
     }
 
     /** Test copy from workspace containing default ant excludes */
+    @Test
     public void testCopyFromWorkspaceWithDefaultExcludes() throws Exception {
-        FreeStyleProject other = createFreeStyleProject(), p = createFreeStyleProject();
+        FreeStyleProject other = rule.createFreeStyleProject(), p = rule.createFreeStyleProject();
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(other.getName(), "", new WorkspaceSelector(),
                 "", "", false, false));
         // Run a build that places a file in the workspace, but does not archive anything
         other.getBuildersList().add(new ArtifactBuilder());
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertFile(true, ".hg/defaultexclude.txt", b);
     }
 
+    @Test
     public void testExcludes() throws Exception {
-        FreeStyleProject other = createFreeStyleProject(), p = createFreeStyleProject();
+        FreeStyleProject other = rule.createFreeStyleProject(), p = rule.createFreeStyleProject();
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(other.getName(), "", new WorkspaceSelector(),
                 "**", ".hg/**", "", false, false, true));
         // Run a build that places a file in the workspace, but does not archive anything
         other.getBuildersList().add(new ArtifactBuilder());
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertFile(true, "subdir/subfoo.txt", b);
         assertFile(false, ".hg/defaultexclude.txt", b);
     }
 
+    @Test
     public void testCopyFromWorkspaceWithDefaultExcludesWithFlatten() throws Exception {
-        FreeStyleProject other = createFreeStyleProject(), p = createFreeStyleProject();
+        FreeStyleProject other = rule.createFreeStyleProject(), p = rule.createFreeStyleProject();
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(other.getName(), "", new WorkspaceSelector(),
                 "", "", true, false));
         // Run a build that places a file in the workspace, but does not archive anything
         other.getBuildersList().add(new ArtifactBuilder());
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertFile(true, "defaultexclude.txt", b);
     }
 
+    @Test
     public void testExcludesWithFlatten() throws Exception {
-        FreeStyleProject other = createFreeStyleProject(), p = createFreeStyleProject();
+        FreeStyleProject other = rule.createFreeStyleProject(), p = rule.createFreeStyleProject();
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(other.getName(), "", new WorkspaceSelector(),
                 "**", ".hg/**", "", true, false, true));
         // Run a build that places a file in the workspace, but does not archive anything
         other.getBuildersList().add(new ArtifactBuilder());
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertFile(true, "subfoo.txt", b);
         assertFile(false, "defaultexclude.txt", b);
     }
 
     /** projectName in CopyArtifact build steps should be updated if a job is renamed */
+    @Test
     public void testJobRename() throws Exception {
-        FreeStyleProject other = createFreeStyleProject(),
+        FreeStyleProject other = rule.createFreeStyleProject(),
                          p = createProject(other.getName(), null, "", "", true, false, false, true);
         assertEquals("before", other.getName(),
                      ((CopyArtifact)p.getBuilders().get(0)).getProjectName());
@@ -561,183 +597,191 @@ public class CopyArtifactTest extends HudsonTestCase {
                      ((CopyArtifact)mp.getBuilders().get(0)).getProjectName());
     }
 
+    @Test
     public void testSavedBuildSelector() throws Exception {
         FreeStyleProject other = createArtifactProject(),
-                         p = createFreeStyleProject();
+                         p = rule.createFreeStyleProject();
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(other.getName(),
                 null, new SavedBuildSelector(), "*.txt", "", false, false, true));
         FreeStyleBuild b = other.scheduleBuild2(0, new UserCause(),
                 new ParametersAction(new StringParameterValue("FOO", "buildone"))).get();
-        assertBuildStatusSuccess(b);
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()));
+        rule.assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()));
         b.keepLog(true);
         b = p.scheduleBuild2(0, new UserCause()).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertFile(true, "foo.txt", b);
         assertFile(true, "buildone.txt", b);
         assertFile(false, "subdir/subfoo.txt", b);
     }
 
+    @Test
     public void testSpecificBuildSelector() throws Exception {
         FreeStyleProject other = createArtifactProject(),
-                         p = createFreeStyleProject();
+                         p = rule.createFreeStyleProject();
         SpecificBuildSelector sbs = new SpecificBuildSelector("1");
         assertEquals("1", sbs.getBuildNumber());
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(other.getName(), null, sbs, "*.txt", "", false, false, true));
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause(),
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause(),
                 new ParametersAction(new StringParameterValue("FOO", "buildone"))).get());
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()));
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()));
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertFile(true, "foo.txt", b);
         assertFile(true, "buildone.txt", b);
         assertFile(false, "subdir/subfoo.txt", b);
     }
 
+    @Test
     public void testSpecificBuildSelectorParameter() throws Exception {
         FreeStyleProject other = createArtifactProject(),
-                         p = createFreeStyleProject();
+                         p = rule.createFreeStyleProject();
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(other.getName(),
                 null, new SpecificBuildSelector("$BAR"), "*.txt", "", false, false, true));
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause(),
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause(),
                 new ParametersAction(new StringParameterValue("FOO", "buildone"))).get());
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()));
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()));
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause(),
                 new ParametersAction(new StringParameterValue("BAR", "1"))).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertFile(true, "foo.txt", b);
         assertFile(true, "buildone.txt", b);
         assertFile(false, "subdir/subfoo.txt", b);
     }
 
+    @Test
     public void testParameterizedBuildSelector() throws Exception {
         FreeStyleProject other = createArtifactProject(),
-                         p = createFreeStyleProject();
+                         p = rule.createFreeStyleProject();
         ParameterizedBuildSelector pbs = new ParameterizedBuildSelector("PBS");
         assertEquals("PBS", pbs.getParameterName());
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(other.getName(), null, pbs, "*.txt", "", false, false, true));
         FreeStyleBuild b = other.scheduleBuild2(0, new UserCause(),
                 new ParametersAction(new StringParameterValue("FOO", "buildone"))).get();
-        assertBuildStatusSuccess(b);
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()));
+        rule.assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()));
         b.keepLog(true);
         b = p.scheduleBuild2(0, new UserCause(),
                 new ParametersAction(new StringParameterValue("PBS", "<SavedBuildSelector/>"))).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertFile(true, "foo.txt", b);
         assertFile(true, "buildone.txt", b);
         assertFile(false, "subdir/subfoo.txt", b);
     }
 
+    @Test
     public void testPermalinkBuildSelector() throws Exception {
         FreeStyleProject other = createArtifactProject(),
-                         p = createFreeStyleProject();
+                         p = rule.createFreeStyleProject();
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(other.getName(),
                 null, new PermalinkBuildSelector("lastStableBuild"), "*.txt", "", false, false, true));
         FreeStyleBuild b = other.scheduleBuild2(0, new UserCause(),
                 new ParametersAction(new StringParameterValue("FOO", "buildone"))).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         other.getBuildersList().add(new UnstableBuilder());
-        assertBuildStatus(Result.UNSTABLE, other.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatus(Result.UNSTABLE, other.scheduleBuild2(0, new UserCause()).get());
         b = p.scheduleBuild2(0, new UserCause()).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertFile(true, "foo.txt", b);
         assertFile(true, "buildone.txt", b);
         assertFile(false, "subdir/subfoo.txt", b);
         // Invalid permalink
         p.getBuildersList().replace(CopyArtifactUtil.createCopyArtifact(other.getName(),
                 null, new PermalinkBuildSelector("fooBuild"), "*.txt", "", false, false, true));
-        assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0, new UserCause()).get());
     }
 
+    @Test
     public void testTriggeredBuildSelector() throws Exception {
         FreeStyleProject other = createArtifactProject(),
-                         p = createFreeStyleProject();
+                         p = rule.createFreeStyleProject();
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(other.getName(),
                 null, new TriggeredBuildSelector(false), "*.txt", "", false, false, true));
         other.getPublishersList().add(new BuildTrigger(p.getFullName(), false));
-        hudson.rebuildDependencyGraph();
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()));
+        rule.jenkins.rebuildDependencyGraph();
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()));
         // p#1 was triggered, now building.
         FreeStyleBuild b = p.getBuildByNumber(1);
         for (int i = 0; b == null && i < 1000; i++) { Thread.sleep(10); b = p.getBuildByNumber(1); }
         assertNotNull(b);
         while (b.isBuilding()) Thread.sleep(10);
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertFile(true, "foo.txt", b);
         assertFile(false, "subdir/subfoo.txt", b);
         // Verify error if build not triggered by upstream job:
-        assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0, new UserCause()).get());
         // test fallback
         
         //run a failing build to make sure the fallback selects the last successful build
         other.getPublishersList().clear();
         other.getBuildersList().add(new FailureBuilder());
-        assertBuildStatus(Result.FAILURE, other.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatus(Result.FAILURE, other.scheduleBuild2(0, new UserCause()).get());
         
         p.getBuildersList().remove(CopyArtifact.class);
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(other.getName(),
                 null, new TriggeredBuildSelector(true), "*.txt", "", false, false, true));
-        assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0, new UserCause()).get());
     }
 
+    @Test
     public void testTriggeredBuildSelectorWithParentOfParent() throws Exception {
         FreeStyleProject grandparent = createArtifactProject(),
-                         parent = createFreeStyleProject(),
-                         p = createFreeStyleProject();
+                         parent = rule.createFreeStyleProject(),
+                         p = rule.createFreeStyleProject();
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(grandparent.getName(), null,
                 new TriggeredBuildSelector(false), "*.txt", "", false, false, true));
         parent.getPublishersList().add(new BuildTrigger(p.getFullName(), false));
         grandparent.getPublishersList().add(new BuildTrigger(parent.getFullName(), false));
-        hudson.rebuildDependencyGraph();
-        assertBuildStatusSuccess(grandparent.scheduleBuild2(0, new UserCause()));
+        rule.jenkins.rebuildDependencyGraph();
+        rule.assertBuildStatusSuccess(grandparent.scheduleBuild2(0, new UserCause()));
         // parent#1 was triggered
         FreeStyleBuild b = parent.getBuildByNumber(1);
         for (int i = 0; b == null && i < 2000; i++) { Thread.sleep(10); b = p.getBuildByNumber(1); }
         assertNotNull(b);
         while (b.isBuilding()) Thread.sleep(10);
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         // p#1 was triggered, now building.
         b = p.getBuildByNumber(1);
         for (int i = 0; b == null && i < 2000; i++) { Thread.sleep(10); b = p.getBuildByNumber(1); }
         assertNotNull(b);
         while (b.isBuilding()) Thread.sleep(10);
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertFile(true, "foo.txt", b);
         assertFile(false, "subdir/subfoo.txt", b);
         // Verify error if build not triggered by upstream job:
-        assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0, new UserCause()).get());
         // test fallback
         
         //run a failing build to make sure the fallback selects the last successful build
         grandparent.getPublishersList().clear();
         grandparent.getBuildersList().add(new FailureBuilder());
-        assertBuildStatus(Result.FAILURE, grandparent.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatus(Result.FAILURE, grandparent.scheduleBuild2(0, new UserCause()).get());
         
         p.getBuildersList().remove(CopyArtifact.class);
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(grandparent.getName(), null,
                 new TriggeredBuildSelector(true), "*.txt", "", false, false, true));
-        assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0, new UserCause()).get());
     }
 
     /**
      * When copying from a particular matrix configuration, the upstream project
      * is the matrix parent.
      */
+    @Test
     public void testTriggeredBuildSelectorFromMatrix() throws Exception {
         MatrixProject other = createMatrixArtifactProject();
-        FreeStyleProject p = createFreeStyleProject();
+        FreeStyleProject p = rule.createFreeStyleProject();
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(other.getName() + "/FOO=two",
                 null, new TriggeredBuildSelector(false), "*.txt", "", false, false, true));
         other.getPublishersList().add(new BuildTrigger(p.getFullName(), false));
-        hudson.rebuildDependencyGraph();
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
+        rule.jenkins.rebuildDependencyGraph();
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         // p#1 was triggered, now building.
         FreeStyleBuild b = p.getBuildByNumber(1);
         for (int i = 0; b == null && i < 1000; i++) { Thread.sleep(10); b = p.getBuildByNumber(1); }
         assertNotNull(b);
         while (b.isBuilding()) Thread.sleep(10);
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertFile(true, "foo.txt", b);
         assertFile(true, "two.txt", b);
     }
@@ -746,6 +790,7 @@ public class CopyArtifactTest extends HudsonTestCase {
      * When copying to a matrix job, need to check the upstream cause of the
      * matrix parent.
      */
+    @Test
     public void testTriggeredBuildSelectorToMatrix() throws Exception {
         FreeStyleProject other = createArtifactProject();
         MatrixProject p = createMatrixProject();
@@ -753,62 +798,67 @@ public class CopyArtifactTest extends HudsonTestCase {
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(other.getName(),
                 null, new TriggeredBuildSelector(false), "*.txt", "", false, false, true));
         other.getPublishersList().add(new BuildTrigger(p.getFullName(), false));
-        hudson.rebuildDependencyGraph();
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
+        rule.jenkins.rebuildDependencyGraph();
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         // p#1 was triggered, now building.
         MatrixBuild b = p.getBuildByNumber(1);
         for (int i = 0; b == null && i < 1000; i++) { Thread.sleep(10); b = p.getBuildByNumber(1); }
         assertNotNull(b);
         while (b.isBuilding()) Thread.sleep(10);
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         MatrixRun r = b.getRuns().get(0);
         assertFile(true, "foo.txt", r);
     }
 
+    @Test
     public void testFlatten() throws Exception {
         FreeStyleProject other = createArtifactProject(),
                          p = createProject(other.getName(), null, "", "newdir", false, true, false, true);
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertFile(true, "newdir/foo.txt", b);
         assertFile(true, "newdir/subfoo.txt", b);
         assertFile(true, "newdir/c.log", b);
     }
 
+    @Test
     public void testOptional_MissingProject() throws Exception {
         // Missing project still fails even when copy is optional
         FreeStyleProject p = createProject("invalid", null, "", "", false, false, true, true);
-        assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0, new UserCause()).get());
     }
 
+    @Test
     public void testOptional_MissingBuild() throws Exception {
-        FreeStyleProject other = createFreeStyleProject(),
+        FreeStyleProject other = rule.createFreeStyleProject(),
                          p = createProject(other.getName(), null, "", "", false, false, true, true);
-        assertBuildStatusSuccess(p.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatusSuccess(p.scheduleBuild2(0, new UserCause()).get());
     }
 
+    @Test
     public void testOptional_MissingArtifact() throws Exception {
-        FreeStyleProject other = createFreeStyleProject(),
+        FreeStyleProject other = rule.createFreeStyleProject(),
                          p = createProject(other.getName(), null, "*.txt", "", false, false, true, true);
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
-        assertBuildStatusSuccess(p.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatusSuccess(p.scheduleBuild2(0, new UserCause()).get());
     }
 
     /**
      * Test that a user is prevented from bypassing permissions on other jobs when configuring
      * a copyartifact build step.
      */
+    @Test
     public void testPermission() throws Exception {
         // any users can be authenticated with the password same to the user id.
-        jenkins.setSecurityRealm(createDummySecurityRealm());
+        rule.jenkins.setSecurityRealm(rule.createDummySecurityRealm());
         ProjectMatrixAuthorizationStrategy pmas = new ProjectMatrixAuthorizationStrategy();
         pmas.add(Jenkins.READ, Jenkins.ANONYMOUS.getName());
         pmas.add(Jenkins.READ, "joe");
-        jenkins.setAuthorizationStrategy(pmas);
+        rule.jenkins.setAuthorizationStrategy(pmas);
         
         // only joe can access project "src"
-        FreeStyleProject src = createFreeStyleProject();
+        FreeStyleProject src = rule.createFreeStyleProject();
         {
             Map<Permission, Set<String>> auths = new HashMap<Permission, Set<String>>();
             auths.put(Item.READ, Sets.newHashSet("joe"));
@@ -817,7 +867,7 @@ public class CopyArtifactTest extends HudsonTestCase {
         
         // test access from anonymous
         {
-            FreeStyleProject dest = createFreeStyleProject();
+            FreeStyleProject dest = rule.createFreeStyleProject();
             dest.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(
                     src.getName(),
                     "",
@@ -833,24 +883,24 @@ public class CopyArtifactTest extends HudsonTestCase {
             auths.put(Item.CONFIGURE, Sets.newHashSet(Jenkins.ANONYMOUS.getName()));
             dest.addProperty(new AuthorizationMatrixProperty(auths));
             
-            WebClient wc = createWebClient();
+            WebClient wc = rule.createWebClient();
             try {
                 wc.getPage(src);
                 fail("Job should not be accessible to anonymous");
             } catch(FailingHttpStatusCodeException e) {
                 assertEquals("Job should not be accessible to anonymous", 404, e.getStatusCode());
             }
+
+            rule.submit(wc.getPage(dest, "configure").getFormByName("config"));
             
-            submit(wc.getPage(dest, "configure").getFormByName("config"));
-            
-            dest = jenkins.getItemByFullName(dest.getFullName(), FreeStyleProject.class);
+            dest = rule.jenkins.getItemByFullName(dest.getFullName(), FreeStyleProject.class);
             CopyArtifact ca = dest.getBuildersList().getAll(CopyArtifact.class).get(0);
             assertEquals("Should ignore/clear value for inaccessible project", "", ca.getProjectName());
         }
         
         // test access from joe
         {
-            FreeStyleProject dest = createFreeStyleProject();
+            FreeStyleProject dest = rule.createFreeStyleProject();
             dest.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(
                     src.getName(),
                     "",
@@ -866,13 +916,13 @@ public class CopyArtifactTest extends HudsonTestCase {
             auths.put(Item.CONFIGURE, Sets.newHashSet("joe"));
             dest.addProperty(new AuthorizationMatrixProperty(auths));
             
-            WebClient wc = createWebClient();
+            WebClient wc = rule.createWebClient();
             wc.login("joe", "joe");
             assertNotNull(wc.getPage(src));
+
+            rule.submit(wc.getPage(dest, "configure").getFormByName("config"));
             
-            submit(wc.getPage(dest, "configure").getFormByName("config"));
-            
-            dest = jenkins.getItemByFullName(dest.getFullName(), FreeStyleProject.class);
+            dest = rule.jenkins.getItemByFullName(dest.getFullName(), FreeStyleProject.class);
             CopyArtifact ca = dest.getBuildersList().getAll(CopyArtifact.class).get(0);
             assertEquals("Should ignore/clear value for inaccessible project", src.getName(), ca.getProjectName());
         }
@@ -884,6 +934,7 @@ public class CopyArtifactTest extends HudsonTestCase {
      * Only jobs accessible to all authenticated users are allowed.
      */
     @LocalData
+    @Test
     public void testPermissionWhenParameterized() throws Exception {
         FreeStyleProject p = createProject("test$JOB", null, "", "", false, false, false, true);
         // Build step should succeed when this parameter expands to a job accessible
@@ -892,7 +943,7 @@ public class CopyArtifactTest extends HudsonTestCase {
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause(),
                 new ParametersAction(new StringParameterValue("JOB", "Job2"))).get();
         assertFile(true, "foo2.txt", b);
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         // Build step should fail for a job not accessible to all authenticated users,
         // even when accessible to the user starting the job, as in this case:
         SecurityContext old = ACL.impersonate(
@@ -901,13 +952,14 @@ public class CopyArtifactTest extends HudsonTestCase {
         b = p.scheduleBuild2(0, new UserCause(),
                 new ParametersAction(new StringParameterValue("JOB", "Job"))).get();
         assertFile(false, "foo.txt", b);
-        assertBuildStatus(Result.FAILURE, b);
+            rule.assertBuildStatus(Result.FAILURE, b);
         } finally {
             SecurityContextHolder.setContext(old);
         }
     }
 
     @LocalData
+    @Test
     public void testPermissionWhenParameterizedForMatrixConfig() throws Exception {
         // This test fails before Jenkins 1.406
         if (new VersionNumber("1.406").isNewerThan(Hudson.getVersion())) return; // Skip
@@ -918,10 +970,11 @@ public class CopyArtifactTest extends HudsonTestCase {
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause(),
                 new ParametersAction(new StringParameterValue("FOO", "foo"))).get();
         assertFile(true, "foo.txt", b);
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
     }
 
     @LocalData
+    @Test
     public void testPermissionWhenParameterizedForMavenModule() throws Exception {
         // This test fails before Jenkins 1.406
         if (new VersionNumber("1.406").isNewerThan(Hudson.getVersion())) return; // Skip
@@ -929,7 +982,7 @@ public class CopyArtifactTest extends HudsonTestCase {
         MavenModuleSet mp = setupMavenJob();
         mp.addProperty(new AuthorizationMatrixProperty(
                 Collections.singletonMap(Item.READ, Collections.singleton("authenticated"))));
-        assertBuildStatusSuccess(mp.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatusSuccess(mp.scheduleBuild2(0, new UserCause()).get());
         FreeStyleProject p = createProject(mp.getName() + "/org.jvnet.hudson.main.test.multimod$FOO",
                                            null, "", "", false, false, false, true);
         // Build step should succeed when this parameter expands to a job accessible to
@@ -941,12 +994,13 @@ public class CopyArtifactTest extends HudsonTestCase {
         assertFile(true, dir + pomName("moduleA", "1.0-SNAPSHOT"), b);
         assertFile(false, dir + "moduleB/1.0-SNAPSHOT/moduleB-1.0-SNAPSHOT.jar", b);
         assertFile(false, dir + pomName("moduleB", "1.0-SNAPSHOT"), b);
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
     }
 
     /**
      * Test that info about selected builds is added into the environment for later build steps.
      */
+    @Test
     public void testEnvData() throws Exception {
         // Also test conversion of job name to env var name, only keeping letters:
         FreeStyleProject other = createArtifactProject("My (Test) Job"),
@@ -955,19 +1009,20 @@ public class CopyArtifactTest extends HudsonTestCase {
         p.getBuildersList().add(envStep);
         // Bump up the build number a bit:
         for (int i = 0; i < 3; i++) other.assignBuildNumber();
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertEquals("4", envStep.getEnvVars().get("COPYARTIFACT_BUILD_NUMBER_MY_TEST_JOB"));
     }
 
-    @Bug(16028)
+    @Issue("JENKINS-16028")
+    @Test
     public void testEnvDataInMavenProject() throws Exception {
-        FreeStyleProject upstream = createFreeStyleProject("upstream");
+        FreeStyleProject upstream = rule.createFreeStyleProject("upstream");
         upstream.getBuildersList().add(new FileWriteBuilder("artifact.txt", "foobar"));
         upstream.getPublishersList().add(new ArtifactArchiver("**/*", "", false, false));
         FreeStyleBuild upstreamBuild = upstream.scheduleBuild2(0).get();
-        assertBuildStatusSuccess(upstreamBuild);
+        rule.assertBuildStatusSuccess(upstreamBuild);
         
         MavenModuleSet downstream = setupMavenJob();
         downstream.getPrebuilders().add(CopyArtifactUtil.createCopyArtifact(
@@ -985,7 +1040,7 @@ public class CopyArtifactTest extends HudsonTestCase {
         downstream.getPrebuilders().add(envStep);
         
         MavenModuleSetBuild downstreamBuild = downstream.scheduleBuild2(0).get();
-        assertBuildStatusSuccess(downstreamBuild);
+        rule.assertBuildStatusSuccess(downstreamBuild);
         assertFile(true, "artifact.txt", downstreamBuild);
         assertEquals(
                 Integer.toString(upstreamBuild.getNumber()),
@@ -993,15 +1048,16 @@ public class CopyArtifactTest extends HudsonTestCase {
         );
     }
     
-    @Bug(18762)
+    @Issue("JENKINS-18762")
+    @Test
     public void testEnvDataWrapped() throws Exception {
-        FreeStyleProject upstream = createFreeStyleProject("upstream");
+        FreeStyleProject upstream = rule.createFreeStyleProject("upstream");
         upstream.getBuildersList().add(new FileWriteBuilder("artifact.txt", "foobar"));
         upstream.getPublishersList().add(new ArtifactArchiver("**/*", "", false, false));
         FreeStyleBuild upstreamBuild = upstream.scheduleBuild2(0).get();
-        assertBuildStatusSuccess(upstreamBuild);
+        rule.assertBuildStatusSuccess(upstreamBuild);
         
-        FreeStyleProject downstream = createFreeStyleProject();
+        FreeStyleProject downstream = rule.createFreeStyleProject();
         downstream.getBuildersList().add(new WrapperBuilder(CopyArtifactUtil.createCopyArtifact(
                 "upstream",
                 "",
@@ -1017,7 +1073,7 @@ public class CopyArtifactTest extends HudsonTestCase {
         downstream.getBuildersList().add(envStep);
         
         FreeStyleBuild downstreamBuild = downstream.scheduleBuild2(0).get();
-        assertBuildStatusSuccess(downstreamBuild);
+        rule.assertBuildStatusSuccess(downstreamBuild);
         assertFile(true, "artifact.txt", downstreamBuild);
         assertEquals(
                 Integer.toString(upstreamBuild.getNumber()),
@@ -1028,6 +1084,7 @@ public class CopyArtifactTest extends HudsonTestCase {
     /**
      * Test filtering on parameters, ie. last stable build with parameter FOO=bar.
      */
+    @Test
     public void testFilterByParameters() throws Exception {
         FreeStyleProject other = createArtifactProject("Foo job");
         other.addProperty(new ParametersDefinitionProperty(
@@ -1035,17 +1092,17 @@ public class CopyArtifactTest extends HudsonTestCase {
                 new BooleanParameterDefinition("BAR", false, ""),
                 new ChoiceParameterDefinition("BAZ", new String[] { "foo", "bar", "baz" }, "")));
         // #1: FOO=foo BAR=false BAZ=baz
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause(), new ParametersAction(
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause(), new ParametersAction(
                 new StringParameterValue("FOO", "foo"),
                 new BooleanParameterValue("BAR", false),
                 new StringParameterValue("BAZ", "baz"))).get());
         // #2: FOO=bar BAR=true BAZ=foo
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause(), new ParametersAction(
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause(), new ParametersAction(
                 new StringParameterValue("FOO", "bar"),
                 new BooleanParameterValue("BAR", true),
                 new StringParameterValue("BAZ", "foo"))).get());
         // #3: FOO=foo BAR=true BAZ=bar
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause(), new ParametersAction(
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause(), new ParametersAction(
                 new StringParameterValue("FOO", "foo"),
                 new BooleanParameterValue("BAR", true),
                 new StringParameterValue("BAZ", "bar"))).get());
@@ -1054,36 +1111,36 @@ public class CopyArtifactTest extends HudsonTestCase {
         CaptureEnvironmentBuilder envStep = new CaptureEnvironmentBuilder();
         p.getBuildersList().add(envStep);
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertEquals("2", envStep.getEnvVars().get("COPYARTIFACT_BUILD_NUMBER_FOO_JOB"));
 
         p = createProject(other.getName(), "BAR=false", "*.txt", "", true, false, false, true);
         p.getBuildersList().add(envStep);
         b = p.scheduleBuild2(0, new UserCause()).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertEquals("1", envStep.getEnvVars().get("COPYARTIFACT_BUILD_NUMBER_FOO_JOB"));
 
         p = createProject(other.getName(), "BAZ=foo,BAR=true", "*.txt", "", true, false, false, true);
         p.getBuildersList().add(envStep);
         b = p.scheduleBuild2(0, new UserCause()).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertEquals("2", envStep.getEnvVars().get("COPYARTIFACT_BUILD_NUMBER_FOO_JOB"));
 
         p = createProject(other.getName(), "FOO=foo,BAR=false,BAZ=baz", "*.txt", "", true, false, false, true);
         p.getBuildersList().add(envStep);
         b = p.scheduleBuild2(0, new UserCause()).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertEquals("1", envStep.getEnvVars().get("COPYARTIFACT_BUILD_NUMBER_FOO_JOB"));
 
         p = createProject(other.getName(), "BAZ=bar,FOO=bogus", "*.txt", "", true, false, false, true);
         b = p.scheduleBuild2(0, new UserCause()).get();
-        assertBuildStatus(Result.FAILURE, b);
+        rule.assertBuildStatus(Result.FAILURE, b);
 
         // Test matching other build variables besides parameters
         p = createProject(other.getName(), "BUILD_NUMBER=2", "*.txt", "", true, false, false, true);
         p.getBuildersList().add(envStep);
         b = p.scheduleBuild2(0, new UserCause()).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertEquals("2", envStep.getEnvVars().get("COPYARTIFACT_BUILD_NUMBER_FOO_JOB"));
         
         // Test coverage for EnvAction
@@ -1099,62 +1156,67 @@ public class CopyArtifactTest extends HudsonTestCase {
         assertTrue(ok);
     }
 
+    @Test
     public void testFilterByMetaParameters() throws Exception {
         FreeStyleProject other = createArtifactProject("Foo job");
         other.addProperty(new ParametersDefinitionProperty(new BooleanParameterDefinition("BAR", false, "")));
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause(), new ParametersAction(new BooleanParameterValue("BAR", false))).get());
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause(), new ParametersAction(new BooleanParameterValue("BAR", true))).get());
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause(), new ParametersAction(new BooleanParameterValue("BAR", false))).get());
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause(), new ParametersAction(new BooleanParameterValue("BAR", false))).get());
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause(), new ParametersAction(new BooleanParameterValue("BAR", true))).get());
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause(), new ParametersAction(new BooleanParameterValue("BAR", false))).get());
         FreeStyleProject p = createProject(other.getName(), "$VAR=true", "*.txt", "", true, false, false, true);
         p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("VAR", "")));
         CaptureEnvironmentBuilder envStep = new CaptureEnvironmentBuilder();
         p.getBuildersList().add(envStep);
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause(), new ParametersAction(new StringParameterValue("VAR", "BAR"))).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertEquals("2", envStep.getEnvVars().get("COPYARTIFACT_BUILD_NUMBER_FOO_JOB"));
     }
 
+    @Test
     public void testSavedBuildSelectorWithParameterFilter() throws Exception {
         FreeStyleProject other = createArtifactProject(),
-                         p = createFreeStyleProject();
+                         p = rule.createFreeStyleProject();
         other.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("FOO", "")));
         FreeStyleBuild b = other.scheduleBuild2(0, new UserCause(),
                 new ParametersAction(new StringParameterValue("FOO", "buildone"))).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         b.keepLog(true);
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(other.getName(), "FOO=buildone",
                 new SavedBuildSelector(), "*.txt", "", false, false, true));
-        assertBuildStatusSuccess(b = other.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatusSuccess(b = other.scheduleBuild2(0, new UserCause()).get());
         b.keepLog(true); // Keep #2 too, but it doesn't have FOO=buildone so should not be selected
-        assertBuildStatusSuccess(b = p.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatusSuccess(b = p.scheduleBuild2(0, new UserCause()).get());
         assertFile(true, "foo.txt", b);
         assertFile(true, "buildone.txt", b);
         assertFile(false, "subdir/subfoo.txt", b);
     }
 
     // Verify build fails if given build# does not match params
+    @Test
     public void testSpecificBuildSelectorWithParameterFilter() throws Exception {
         FreeStyleProject other = createArtifactProject(),
-                         p = createFreeStyleProject();
+                         p = rule.createFreeStyleProject();
         other.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("FOO", "")));
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(other.getName(), "FOO=bogus",
                 new SpecificBuildSelector("1"), "*.txt", "", false, false, true));
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause(),
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause(),
                 new ParametersAction(new StringParameterValue("FOO", "foo"))).get());
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()));
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()));
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
-        assertBuildStatus(Result.FAILURE, b);
+        rule.assertBuildStatus(Result.FAILURE, b);
         assertFile(false, "foo.txt", b);
     }
 
     // Verify BuildSelector defaults to false
+    @Test
     public void testBuildSelectorDefault() {
         assertFalse(new BuildSelector() { }.isSelectable(null, null));
     }
 
     // Test field getters
+    @Test
     public void testFields() throws Exception {
-        FreeStyleProject p = createFreeStyleProject();
+        FreeStyleProject p = rule.createFreeStyleProject();
         CopyArtifact ca = CopyArtifactUtil.createCopyArtifact(p.getFullName(), null, new SavedBuildSelector(), "filter", "target", false, true, true);
         assertEquals(p.getFullName(), ca.getProjectName());
         assertSame(SavedBuildSelector.class, ca.getBuildSelector().getClass());
@@ -1167,9 +1229,10 @@ public class CopyArtifactTest extends HudsonTestCase {
         assertFalse(ca.isOptional());
     }
 
+    @Test
     public void testFieldValidation() throws Exception {
-        FreeStyleProject p = createFreeStyleProject();
-        CopyArtifact.DescriptorImpl descriptor = hudson.getDescriptorByType(CopyArtifact.DescriptorImpl.class);
+        FreeStyleProject p = rule.createFreeStyleProject();
+        CopyArtifact.DescriptorImpl descriptor = rule.jenkins.getDescriptorByType(CopyArtifact.DescriptorImpl.class);
         assertNotNull(descriptor);
         // Valid value
         assertSame(FormValidation.Kind.OK, descriptor.doCheckProjectName(p, p.getFullName()).kind);
@@ -1178,7 +1241,7 @@ public class CopyArtifactTest extends HudsonTestCase {
         // Parameterized value
         assertSame(FormValidation.Kind.WARNING, descriptor.doCheckProjectName(p, "$FOO").kind);
         // Just returns OK if no permission
-        hudson.setAuthorizationStrategy(new GlobalMatrixAuthorizationStrategy());
+        rule.jenkins.setAuthorizationStrategy(new GlobalMatrixAuthorizationStrategy());
         SecurityContextHolder.clearContext();
         assertSame(FormValidation.Kind.OK, descriptor.doCheckProjectName(p, "").kind);
         // Other descriptor methods
@@ -1187,6 +1250,7 @@ public class CopyArtifactTest extends HudsonTestCase {
     }
 
     @LocalData
+    @Test
     public void testProjectNameSplit() throws Exception {
         FreeStyleProject copier = Jenkins.getInstance().getItemByFullName("copier", FreeStyleProject.class);
         assertNotNull(copier);
@@ -1230,6 +1294,7 @@ public class CopyArtifactTest extends HudsonTestCase {
     }
     
     @LocalData
+    @Test
     public void testWrappedCopierProjectNameSplit() throws Exception {
         // Project "copier" is configured with CopyArtifact wrapped with WrapBuilder.
         // This causes failure of upgrading on loaded.
@@ -1242,7 +1307,7 @@ public class CopyArtifactTest extends HudsonTestCase {
         
         // upgraded when a build is triggered.
         FreeStyleBuild b = copier.scheduleBuild2(0).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         FilePath fileToTest = b.getWorkspace().child("from-plain/tag.txt");
         assertTrue(fileToTest.exists());
         assertEquals("jenkins-plain-2\n", fileToTest.readToString());
@@ -1252,159 +1317,168 @@ public class CopyArtifactTest extends HudsonTestCase {
         assertTrue(configXml, configXml.contains("<project>plain</project>"));
     }
     
-    @Bug(17447)
+    @Issue("JENKINS-17447")
     @LocalData
+    @Test
     public void testRenameBeforeProjectNameSplit() throws Exception {
-        jenkins.getItemByFullName("old", FreeStyleProject.class).renameTo("new");
-        FreeStyleProject nue = jenkins.getItemByFullName("new", FreeStyleProject.class);
-        assertBuildStatusSuccess(nue.scheduleBuild2(0));
-        FreeStyleProject copier = jenkins.getItemByFullName("copier", FreeStyleProject.class);
-        assertBuildStatusSuccess(copier.scheduleBuild2(0));
+        rule.jenkins.getItemByFullName("old", FreeStyleProject.class).renameTo("new");
+        FreeStyleProject nue = rule.jenkins.getItemByFullName("new", FreeStyleProject.class);
+        rule.assertBuildStatusSuccess(nue.scheduleBuild2(0));
+        FreeStyleProject copier = rule.jenkins.getItemByFullName("copier", FreeStyleProject.class);
+        rule.assertBuildStatusSuccess(copier.scheduleBuild2(0));
         assertEquals("jenkins-new-1\n", copier.getLastBuild().getWorkspace().child("stuff").readToString());
     }
 
+    @Test
     public void testRelative() throws Exception {
-        MockFolder folder = jenkins.createProject(MockFolder.class, "folder");
+        MockFolder folder = rule.jenkins.createProject(MockFolder.class, "folder");
         FreeStyleProject other = folder.createProject(FreeStyleProject.class, "foo");
         other.getBuildersList().add(new ArtifactBuilder());
         other.getPublishersList().add(new ArtifactArchiver("**", "", false, false));
 
         FreeStyleProject p = createProject("folder/foo", null, "", "", true, false, false, true);
 
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertFile(true, "foo.txt", b);
     }
 
+    @Test
     public void testAbsolute() throws Exception {
-        MockFolder folder = jenkins.createProject(MockFolder.class, "folder");
+        MockFolder folder = rule.jenkins.createProject(MockFolder.class, "folder");
         FreeStyleProject other = folder.createProject(FreeStyleProject.class, "foo");
         other.getBuildersList().add(new ArtifactBuilder());
         other.getPublishersList().add(new ArtifactArchiver("**", "", false, false));
 
         FreeStyleProject p = createProject("/folder/foo", null, "", "", true, false, false, true);
 
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertFile(true, "foo.txt", b);
     }
 
-    @Bug(19833)
+    @Issue("JENKINS-19833")
+    @Test
     public void testMostlyAbsolute() throws Exception {
-        MockFolder folder = jenkins.createProject(MockFolder.class, "folder");
+        MockFolder folder = rule.jenkins.createProject(MockFolder.class, "folder");
         FreeStyleProject other = folder.createProject(FreeStyleProject.class, "foo");
         other.getBuildersList().add(new ArtifactBuilder());
         other.getPublishersList().add(new ArtifactArchiver("**", "", false, false));
 
-        MockFolder folder2 = jenkins.createProject(MockFolder.class, "other");
+        MockFolder folder2 = rule.jenkins.createProject(MockFolder.class, "other");
         FreeStyleProject p = folder2.createProject(FreeStyleProject.class, "bar");
 
         // "folder/foo" should be resolved as "/folder/foo" even from "/other/bar", for backward compatibility
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact("folder/foo", null, new StatusBuildSelector(true), "", "", false, false, true));
 
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertFile(true, "foo.txt", b);
     }
 
+    @Test
     public void testAbsoluteFromFolder() throws Exception {
-        FreeStyleProject other = jenkins.createProject(FreeStyleProject.class, "foo");
+        FreeStyleProject other = rule.jenkins.createProject(FreeStyleProject.class, "foo");
         other.getBuildersList().add(new ArtifactBuilder());
         other.getPublishersList().add(new ArtifactArchiver("**", "", false, false));
 
-        MockFolder folder = jenkins.createProject(MockFolder.class, "folder");
+        MockFolder folder = rule.jenkins.createProject(MockFolder.class, "folder");
         FreeStyleProject p = folder.createProject(FreeStyleProject.class, "bar");
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact("/foo", null, new StatusBuildSelector(true), "", "", false, false, true));
 
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertFile(true, "foo.txt", b);
     }
 
+    @Test
     public void testRelativeFromFolder() throws Exception {
-        FreeStyleProject other = jenkins.createProject(FreeStyleProject.class, "foo");
+        FreeStyleProject other = rule.jenkins.createProject(FreeStyleProject.class, "foo");
         other.getBuildersList().add(new ArtifactBuilder());
         other.getPublishersList().add(new ArtifactArchiver("**", "", false, false));
 
-        MockFolder folder = jenkins.createProject(MockFolder.class, "folder");
+        MockFolder folder = rule.jenkins.createProject(MockFolder.class, "folder");
         FreeStyleProject p = folder.createProject(FreeStyleProject.class, "bar");
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact("../foo", null, new StatusBuildSelector(true), "", "", false, false, true));
 
-        assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
+        rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause()).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertFile(true, "foo.txt", b);
     }
 
+    @Test
     public void testSameFolder() throws Exception {
-        Folder folder = jenkins.createProject(Folder.class, "folder");
+        Folder folder = rule.jenkins.createProject(Folder.class, "folder");
         FreeStyleProject src = folder.createProject(FreeStyleProject.class, "src");
         src.getBuildersList().add(new ArtifactBuilder());
         src.getPublishersList().add(new ArtifactArchiver("**", "", false, false));
-        assertBuildStatusSuccess(src.scheduleBuild2(0));
+        rule.assertBuildStatusSuccess(src.scheduleBuild2(0));
         
         FreeStyleProject dest = folder.createProject(FreeStyleProject.class, "dest");
         dest.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(src.getName(), null, new StatusBuildSelector(true), "", "", false, false, true));
         FreeStyleBuild b = dest.scheduleBuild2(0).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertFile(true, "foo.txt", b);
         
-        WebClient wc = createWebClient();
-        submit(wc.getPage(dest, "configure").getFormByName("config"));
+        WebClient wc = rule.createWebClient();
+        rule.submit(wc.getPage(dest, "configure").getFormByName("config"));
         
-        dest = jenkins.getItemByFullName(dest.getFullName(), FreeStyleProject.class);
+        dest = rule.jenkins.getItemByFullName(dest.getFullName(), FreeStyleProject.class);
         CopyArtifact ca = (CopyArtifact)dest.getBuildersList().get(0);
         assertEquals(src.getName(), ca.getProjectName());
     }
 
+    @Test
     public void testSameFolderFromMatrix() throws Exception {
-        Folder folder = jenkins.createProject(Folder.class, "folder");
+        Folder folder = rule.jenkins.createProject(Folder.class, "folder");
         MatrixProject src = folder.createProject(MatrixProject.class, "src");
         src.setAxes(new AxisList(new TextAxis("axis1", "value1", "value2")));
         src.getBuildersList().add(new ArtifactBuilder());
         src.getPublishersList().add(new ArtifactArchiver("**", "", false, false));
-        assertBuildStatusSuccess(src.scheduleBuild2(0));
+        rule.assertBuildStatusSuccess(src.scheduleBuild2(0));
         
         String projectNameToCopyFrom = String.format("%s/axis1=value1", src.getName());
         FreeStyleProject dest = folder.createProject(FreeStyleProject.class, "dest");
         dest.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(projectNameToCopyFrom, null, new StatusBuildSelector(true), "", "", false, false, true));
         FreeStyleBuild b = dest.scheduleBuild2(0).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         assertFile(true, "foo.txt", b);
         
-        WebClient wc = createWebClient();
-        submit(wc.getPage(dest, "configure").getFormByName("config"));
+        WebClient wc = rule.createWebClient();
+        rule.submit(wc.getPage(dest, "configure").getFormByName("config"));
         
-        dest = jenkins.getItemByFullName(dest.getFullName(), FreeStyleProject.class);
+        dest = rule.jenkins.getItemByFullName(dest.getFullName(), FreeStyleProject.class);
         CopyArtifact ca = (CopyArtifact)dest.getBuildersList().get(0);
         assertEquals(projectNameToCopyFrom, ca.getProjectName());
     }
 
-    @Bug(20940)
+    @Issue("JENKINS-20940")
+    @Test
     public void testSameFolderToMatrix() throws Exception {
-        Folder folder = jenkins.createProject(Folder.class, "foler");
+        Folder folder = rule.jenkins.createProject(Folder.class, "foler");
         FreeStyleProject src = folder.createProject(FreeStyleProject.class, "src");
         src.getBuildersList().add(new ArtifactBuilder());
         src.getPublishersList().add(new ArtifactArchiver("**", "", false, false));
-        assertBuildStatusSuccess(src.scheduleBuild2(0));
+        rule.assertBuildStatusSuccess(src.scheduleBuild2(0));
         
         MatrixProject dest = folder.createProject(MatrixProject.class, "dest");
         dest.setAxes(new AxisList(new TextAxis("axis1", "value1", "value2")));
         dest.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(src.getName(), null, new StatusBuildSelector(true), "", "", false, false, true));
         MatrixBuild b = dest.scheduleBuild2(0).get();
-        assertBuildStatusSuccess(b);
+        rule.assertBuildStatusSuccess(b);
         for(MatrixRun r: b.getExactRuns()) {
             assertFile(true, "foo.txt", r);
         }
         
-        WebClient wc = createWebClient();
-        submit(wc.getPage(dest, "configure").getFormByName("config"));
+        WebClient wc = rule.createWebClient();
+        rule.submit(wc.getPage(dest, "configure").getFormByName("config"));
         
-        dest = jenkins.getItemByFullName(dest.getFullName(), MatrixProject.class);
+        dest = rule.jenkins.getItemByFullName(dest.getFullName(), MatrixProject.class);
         CopyArtifact ca = (CopyArtifact)dest.getBuildersList().get(0);
         assertEquals(src.getName(), ca.getProjectName());
     }
@@ -1412,13 +1486,14 @@ public class CopyArtifactTest extends HudsonTestCase {
     @Test
     @LocalData
     public void testOldCopyArtifactConfigIsLoadedCorrectly() throws Exception {
-        FreeStyleProject p = (FreeStyleProject) jenkins.getItem("copy-artifact");
+        FreeStyleProject p = (FreeStyleProject) rule.jenkins.getItem("copy-artifact");
         CopyArtifact trigger = (CopyArtifact) p.getBuilders().get(0);
 
         assertTrue(trigger.isFingerprintArtifacts());
     }
 
     @LocalData // enable Jenkins security
+    @Test
     public void testCopyArtifactPermissionProperty() throws Exception {
         // invalid permission configuration can hang builds.
         final int TIMEOUT = 60;
@@ -1454,26 +1529,27 @@ public class CopyArtifactTest extends HudsonTestCase {
         assertFalse(matrixCopier.getACL().hasPermission(test1.impersonate(), Item.READ));
         
         // prepare an artifact
-        assertBuildStatusSuccess(copiee.scheduleBuild2(0));
-        assertBuildStatusSuccess(matrixCopiee.scheduleBuild2(0));
+        rule.assertBuildStatusSuccess(copiee.scheduleBuild2(0));
+        rule.assertBuildStatusSuccess(matrixCopiee.scheduleBuild2(0));
         
         // Without CopyArtifactPermissionProperty, build fails with access check.
-        assertBuildStatus(Result.FAILURE, copier.scheduleBuild2(0).get(TIMEOUT, TimeUnit.SECONDS));
-        assertBuildStatus(Result.FAILURE, matrixCopier.scheduleBuild2(0).get(TIMEOUT, TimeUnit.SECONDS));
+        rule.assertBuildStatus(Result.FAILURE, copier.scheduleBuild2(0).get(TIMEOUT, TimeUnit.SECONDS));
+        rule.assertBuildStatus(Result.FAILURE, matrixCopier.scheduleBuild2(0).get(TIMEOUT, TimeUnit.SECONDS));
         
         copiee.addProperty(new CopyArtifactPermissionProperty(copier.getFullName()));
         matrixCopiee.addProperty(new CopyArtifactPermissionProperty(matrixCopier.getFullName()));
         
         // By using CopyArtifactPermissionProperty,
         // builds succeed.
-        assertBuildStatusSuccess(copier.scheduleBuild2(0).get(TIMEOUT, TimeUnit.SECONDS));
-        assertBuildStatusSuccess(matrixCopier.scheduleBuild2(0).get(TIMEOUT, TimeUnit.SECONDS));
+        rule.assertBuildStatusSuccess(copier.scheduleBuild2(0).get(TIMEOUT, TimeUnit.SECONDS));
+        rule.assertBuildStatusSuccess(matrixCopier.scheduleBuild2(0).get(TIMEOUT, TimeUnit.SECONDS));
     }
 
+    @Test
     public void testWebConfiguration() throws Exception {
-        FreeStyleProject upstream1 = createFreeStyleProject();
-        FreeStyleProject upstream2 = createFreeStyleProject();
-        FreeStyleProject p = createFreeStyleProject();
+        FreeStyleProject upstream1 = rule.createFreeStyleProject();
+        FreeStyleProject upstream2 = rule.createFreeStyleProject();
+        FreeStyleProject p = rule.createFreeStyleProject();
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(
                 upstream1.getName(),
                 "",
@@ -1500,10 +1576,10 @@ public class CopyArtifactTest extends HudsonTestCase {
         ));
         p.save();
         
-        WebClient wc = createWebClient();
-        submit(wc.getPage(p, "configure").getFormByName("config"));
+        WebClient wc = rule.createWebClient();
+        rule.submit(wc.getPage(p, "configure").getFormByName("config"));
         
-        p = jenkins.getItemByFullName(p.getFullName(), FreeStyleProject.class);
+        p = rule.jenkins.getItemByFullName(p.getFullName(), FreeStyleProject.class);
         
         List<CopyArtifact> caList = p.getBuildersList().getAll(CopyArtifact.class);
         assertEquals(2, caList.size());
@@ -1536,21 +1612,22 @@ public class CopyArtifactTest extends HudsonTestCase {
     }
     
     private boolean isFilePermissionSupported() throws Exception {
-        return jenkins.getRootPath().mode() != -1;
+        return rule.jenkins.getRootPath().mode() != -1;
     }
     
+    @Test
     public void testFilePermission() throws Exception {
         if (!isFilePermissionSupported()) {
             Logger.getLogger(CopyArtifactTest.class.getName()).warning(String.format(
                     "Skipped %s as file permission is not supported on this platform",
-                    getName()
+                    name.getMethodName()
             ));
             return;
         }
         
-        FreeStyleProject copiee = createFreeStyleProject();
+        FreeStyleProject copiee = rule.createFreeStyleProject();
         FreeStyleBuild copieeBuild = copiee.scheduleBuild2(0).get();
-        assertBuildStatusSuccess(copieeBuild);
+        rule.assertBuildStatusSuccess(copieeBuild);
         
         // As I cannot trust ArtifactArchiver (JENKINS-14269),
         // creates artifacts manually.
@@ -1572,8 +1649,8 @@ public class CopyArtifactTest extends HudsonTestCase {
         
         // on master, without flatten
         {
-            FreeStyleProject p = createFreeStyleProject();
-            p.setAssignedNode(jenkins);
+            FreeStyleProject p = rule.createFreeStyleProject();
+            p.setAssignedNode(rule.jenkins);
             p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(
                     copiee.getFullName(),
                     "",
@@ -1586,9 +1663,9 @@ public class CopyArtifactTest extends HudsonTestCase {
                     false
             ));
             FreeStyleBuild b = p.scheduleBuild2(0).get();
-            assertBuildStatusSuccess(b);
+            rule.assertBuildStatusSuccess(b);
             
-            assertEquals(jenkins, b.getBuiltOn());
+            assertEquals(rule.jenkins, b.getBuiltOn());
             
             FilePath w = b.getWorkspace();
             assertEquals(0644, w.child("artifact.txt").mode() & 0777);
@@ -1599,8 +1676,8 @@ public class CopyArtifactTest extends HudsonTestCase {
         
         // on master, with flatten
         {
-            FreeStyleProject p = createFreeStyleProject();
-            p.setAssignedNode(jenkins);
+            FreeStyleProject p = rule.createFreeStyleProject();
+            p.setAssignedNode(rule.jenkins);
             p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(
                     copiee.getFullName(),
                     "",
@@ -1613,9 +1690,9 @@ public class CopyArtifactTest extends HudsonTestCase {
                     false
             ));
             FreeStyleBuild b = p.scheduleBuild2(0).get();
-            assertBuildStatusSuccess(b);
+            rule.assertBuildStatusSuccess(b);
             
-            assertEquals(jenkins, b.getBuiltOn());
+            assertEquals(rule.jenkins, b.getBuiltOn());
             
             FilePath w = b.getWorkspace();
             assertEquals(0644, w.child("artifact.txt").mode() & 0777);
@@ -1624,11 +1701,11 @@ public class CopyArtifactTest extends HudsonTestCase {
             assertEquals(0755, w.child("artifactWithExecuteInSubdir.txt").mode() & 0777);
         }
         
-        DumbSlave node = createOnlineSlave();
+        DumbSlave node = rule.createOnlineSlave();
         
         // on slave, without flatten
         {
-            FreeStyleProject p = createFreeStyleProject();
+            FreeStyleProject p = rule.createFreeStyleProject();
             p.setAssignedNode(node);
             p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(
                     copiee.getFullName(),
@@ -1642,7 +1719,7 @@ public class CopyArtifactTest extends HudsonTestCase {
                     false
             ));
             FreeStyleBuild b = p.scheduleBuild2(0).get();
-            assertBuildStatusSuccess(b);
+            rule.assertBuildStatusSuccess(b);
             
             assertEquals(node, b.getBuiltOn());
             
@@ -1655,7 +1732,7 @@ public class CopyArtifactTest extends HudsonTestCase {
         
         // on slave, with flatten
         {
-            FreeStyleProject p = createFreeStyleProject();
+            FreeStyleProject p = rule.createFreeStyleProject();
             p.setAssignedNode(node);
             p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(
                     copiee.getFullName(),
@@ -1669,7 +1746,7 @@ public class CopyArtifactTest extends HudsonTestCase {
                     false
             ));
             FreeStyleBuild b = p.scheduleBuild2(0).get();
-            assertBuildStatusSuccess(b);
+            rule.assertBuildStatusSuccess(b);
             
             assertEquals(node, b.getBuiltOn());
             
@@ -1681,9 +1758,10 @@ public class CopyArtifactTest extends HudsonTestCase {
         }
     }
 
-    @Bug(20546)
+    @Issue("JENKINS-20546")
+    @Test
     public void testSymlinks() throws Exception {
-        FreeStyleProject p1 = createFreeStyleProject("p1");
+        FreeStyleProject p1 = rule.createFreeStyleProject("p1");
         p1.getBuildersList().add(new TestBuilder() {
             @Override public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
                 build.getWorkspace().child("plain").write("text", null);
@@ -1693,10 +1771,10 @@ public class CopyArtifactTest extends HudsonTestCase {
             }
         });
         p1.getPublishersList().add(new ArtifactArchiver("**", "", false, false));
-        buildAndAssertSuccess(p1);
-        FreeStyleProject p2 = createFreeStyleProject("p2");
+        rule.buildAndAssertSuccess(p1);
+        FreeStyleProject p2 = rule.createFreeStyleProject("p2");
         p2.getBuildersList().add(CopyArtifactUtil.createCopyArtifact("p1", null, new StatusBuildSelector(true), null, "", false, false, true));
-        FreeStyleBuild b = buildAndAssertSuccess(p2);
+        FreeStyleBuild b = rule.buildAndAssertSuccess(p2);
         FilePath ws = b.getWorkspace();
         assertEquals("text", ws.child("plain").readToString());
         assertEquals("plain", ws.child("link1").readLink());
@@ -1719,6 +1797,7 @@ public class CopyArtifactTest extends HudsonTestCase {
     }
     
     @LocalData
+    @Test
     public void testQueueItemAuthenticator() throws Exception {
         
         // This test may hang without timeout with improper authorization configuration.
@@ -1773,11 +1852,11 @@ public class CopyArtifactTest extends HudsonTestCase {
         assertTrue (Jenkins.getInstance().getACL().hasPermission(Jenkins.ANONYMOUS, Computer.BUILD));
         
         // prepare an artifact
-        assertBuildStatusSuccess(copiee.scheduleBuild2(0));
+        rule.assertBuildStatusSuccess(copiee.scheduleBuild2(0));
         
         // Without QueueItemAuthenticator, build fails with access check.
         {
-            assertBuildStatus(Result.FAILURE, copier.scheduleBuild2(0).get(TIMEOUT, TimeUnit.SECONDS));
+            rule.assertBuildStatus(Result.FAILURE, copier.scheduleBuild2(0).get(TIMEOUT, TimeUnit.SECONDS));
         }
         
         // Set QueueItemAuthenticator to run with authorization of admin.
@@ -1787,7 +1866,7 @@ public class CopyArtifactTest extends HudsonTestCase {
             QueueItemAuthenticatorConfiguration.get().getAuthenticators().add(
                     new TestQueueItemAuthenticator(admin.impersonate())
             );
-            assertBuildStatus(Result.SUCCESS, copier.scheduleBuild2(0).get(TIMEOUT, TimeUnit.SECONDS));
+            rule.assertBuildStatus(Result.SUCCESS, copier.scheduleBuild2(0).get(TIMEOUT, TimeUnit.SECONDS));
         }
         
         // Set QueueItemAuthenticator to run with authorization of test1.
@@ -1797,7 +1876,7 @@ public class CopyArtifactTest extends HudsonTestCase {
             QueueItemAuthenticatorConfiguration.get().getAuthenticators().add(
                     new TestQueueItemAuthenticator(test1.impersonate())
             );
-            assertBuildStatus(Result.SUCCESS, copier.scheduleBuild2(0).get(TIMEOUT, TimeUnit.SECONDS));
+            rule.assertBuildStatus(Result.SUCCESS, copier.scheduleBuild2(0).get(TIMEOUT, TimeUnit.SECONDS));
         }
         
         // Set QueueItemAuthenticator to run with authorization of test2.
@@ -1807,7 +1886,7 @@ public class CopyArtifactTest extends HudsonTestCase {
             QueueItemAuthenticatorConfiguration.get().getAuthenticators().add(
                     new TestQueueItemAuthenticator(test2.impersonate())
             );
-            assertBuildStatus(Result.FAILURE, copier.scheduleBuild2(0).get(TIMEOUT, TimeUnit.SECONDS));
+            rule.assertBuildStatus(Result.FAILURE, copier.scheduleBuild2(0).get(TIMEOUT, TimeUnit.SECONDS));
         }
         
         // Set QueueItemAuthenticator to run with anonymous authentication.
@@ -1817,26 +1896,27 @@ public class CopyArtifactTest extends HudsonTestCase {
             QueueItemAuthenticatorConfiguration.get().getAuthenticators().add(
                     new TestQueueItemAuthenticator(Jenkins.ANONYMOUS)
             );
-            assertBuildStatus(Result.FAILURE, copier.scheduleBuild2(0).get(TIMEOUT, TimeUnit.SECONDS));
+            rule.assertBuildStatus(Result.FAILURE, copier.scheduleBuild2(0).get(TIMEOUT, TimeUnit.SECONDS));
         }
     }
     
     @Issue("JENKINS-28972")
     @LocalData
     @WithPlugin("copyartifact-extension-test.hpi")  // JENKINS-28792 reproduces only when classes are located in different class loaders.
+    @Test
     public void testSimpleBuildSelectorDescriptorInOtherPlugin() throws Exception {
-        WebClient wc = createWebClient();
+        WebClient wc = rule.createWebClient();
         
         // An extension using SimpleBuildSelectorDescriptorSelector
         {
-            FreeStyleProject p = jenkins.getItemByFullName("UsingSimpleBuildSelectorDescriptorSelector", FreeStyleProject.class);
+            FreeStyleProject p = rule.jenkins.getItemByFullName("UsingSimpleBuildSelectorDescriptorSelector", FreeStyleProject.class);
             assertNotNull(p);
             wc.getPage(p, "configure");
         }
         
         // An extension using SimpleBuildSelectorDescriptorSelector without configuration pages.
         {
-            FreeStyleProject p = jenkins.getItemByFullName("NoConfigPageSimpleBuildSelectorDescriptorSelector", FreeStyleProject.class);
+            FreeStyleProject p = rule.jenkins.getItemByFullName("NoConfigPageSimpleBuildSelectorDescriptorSelector", FreeStyleProject.class);
             assertNotNull(p);
             wc.getPage(p, "configure");
         }
@@ -1844,12 +1924,13 @@ public class CopyArtifactTest extends HudsonTestCase {
         // An extension extending SimpleBuildSelectorDescriptorSelector.
         // (Even though generally it is useless)
         {
-            FreeStyleProject p = jenkins.getItemByFullName("ExtendingSimpleBuildSelectorDescriptorSelector", FreeStyleProject.class);
+            FreeStyleProject p = rule.jenkins.getItemByFullName("ExtendingSimpleBuildSelectorDescriptorSelector", FreeStyleProject.class);
             assertNotNull(p);
             wc.getPage(p, "configure");
         }
     }
-    
+
+    @Test
     public void testIsValidVariableName() throws Exception {
         assertTrue(CopyArtifact.isValidVariableName("VarName"));
         assertTrue(CopyArtifact.isValidVariableName("Var_Name"));
@@ -1859,15 +1940,16 @@ public class CopyArtifactTest extends HudsonTestCase {
         assertFalse(CopyArtifact.isValidVariableName("=/?!\""));
     }
     
+    @Test
     public void testResultVariableSuffix() throws Exception {
         FreeStyleProject srcProject = createArtifactProject("SRC-PROJECT1");
         FreeStyleBuild srcBuild = srcProject.scheduleBuild2(0).get();
-        assertBuildStatusSuccess(srcBuild);
+        rule.assertBuildStatusSuccess(srcBuild);
         
         // if no result variable suffix is provided
         // the default suffix (SRC_PROJECT) is used.
         {
-            FreeStyleProject p = createFreeStyleProject();
+            FreeStyleProject p = rule.createFreeStyleProject();
             p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(
                     srcProject.getFullName(),
                     null,       // parameters
@@ -1882,8 +1964,8 @@ public class CopyArtifactTest extends HudsonTestCase {
             ));
             CaptureEnvironmentBuilder ceb = new CaptureEnvironmentBuilder();
             p.getBuildersList().add(ceb);
-            
-            assertBuildStatusSuccess(p.scheduleBuild2(0));
+
+            rule.assertBuildStatusSuccess(p.scheduleBuild2(0));
             
             assertEquals(
                     Integer.toString(srcBuild.getNumber()),
@@ -1894,7 +1976,7 @@ public class CopyArtifactTest extends HudsonTestCase {
         // if result variable suffix is provided
         // it is used for the variable name to store.
         {
-            FreeStyleProject p = createFreeStyleProject();
+            FreeStyleProject p = rule.createFreeStyleProject();
             p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(
                     srcProject.getFullName(),
                     null,       // parameters
@@ -1909,8 +1991,8 @@ public class CopyArtifactTest extends HudsonTestCase {
             ));
             CaptureEnvironmentBuilder ceb = new CaptureEnvironmentBuilder();
             p.getBuildersList().add(ceb);
-            
-            assertBuildStatusSuccess(p.scheduleBuild2(0));
+
+            rule.assertBuildStatusSuccess(p.scheduleBuild2(0));
             
             assertEquals(
                     Integer.toString(srcBuild.getNumber()),
@@ -1922,7 +2004,7 @@ public class CopyArtifactTest extends HudsonTestCase {
         // if result variable suffix is invalid,
         // the default suffix (SRC_PROJECT) is used.
         {
-            FreeStyleProject p = createFreeStyleProject();
+            FreeStyleProject p = rule.createFreeStyleProject();
             p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(
                     srcProject.getFullName(),
                     null,       // parameters
@@ -1937,8 +2019,8 @@ public class CopyArtifactTest extends HudsonTestCase {
             ));
             CaptureEnvironmentBuilder ceb = new CaptureEnvironmentBuilder();
             p.getBuildersList().add(ceb);
-            
-            assertBuildStatusSuccess(p.scheduleBuild2(0));
+
+            rule.assertBuildStatusSuccess(p.scheduleBuild2(0));
             
             assertEquals(
                     Integer.toString(srcBuild.getNumber()),

--- a/src/test/java/hudson/plugins/copyartifact/CopyArtifactWorkflowTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/CopyArtifactWorkflowTest.java
@@ -40,7 +40,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.Bug;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.IOException;
@@ -74,7 +74,7 @@ public class CopyArtifactWorkflowTest {
     /**
      * Test filtering on parameters works to copy from workflow jobs.
      */
-    @Bug(26694)
+    @Issue("JENKINS-26694")
     @Test
     public void testFilterByParametersForWorkflow() throws Exception {
         WorkflowJob copiee = createWorkflow("copiee",

--- a/src/test/java/hudson/plugins/copyartifact/SpecificBuildSelectorTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/SpecificBuildSelectorTest.java
@@ -2,17 +2,24 @@ package hudson.plugins.copyartifact;
 
 import hudson.EnvVars;
 import hudson.model.FreeStyleProject;
-import org.jvnet.hudson.test.Bug;
-import org.jvnet.hudson.test.HudsonTestCase;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
 
-public class SpecificBuildSelectorTest extends HudsonTestCase {
+import static org.junit.Assert.*;
 
-    @Bug(14266)
+public class SpecificBuildSelectorTest {
+    @Rule
+    public final JenkinsRule rule = new JenkinsRule();
+
+    @Issue("JENKINS-14266")
+    @Test
     public void testUnsetVar() throws Exception {
-        FreeStyleProject p = createFreeStyleProject();
-        assertBuildStatusSuccess(p.scheduleBuild2(0));
-        assertBuildStatusSuccess(p.scheduleBuild2(0));
-        assertBuildStatusSuccess(p.scheduleBuild2(0));
+        FreeStyleProject p = rule.createFreeStyleProject();
+        rule.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        rule.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        rule.assertBuildStatusSuccess(p.scheduleBuild2(0));
         assertEquals(3, p.getLastBuild().number);
         BuildSelector s = new SpecificBuildSelector("$NUM");
         BuildFilter f = new BuildFilter();
@@ -20,12 +27,13 @@ public class SpecificBuildSelectorTest extends HudsonTestCase {
         assertEquals(null, s.getBuild(p, new EnvVars("HUM", "two"), f, null));
     }
 
-    @Bug(19693)
+    @Issue("JENKINS-19693")
+    @Test
     public void testDisplayName() throws Exception {
-        FreeStyleProject p = createFreeStyleProject();
-        assertBuildStatusSuccess(p.scheduleBuild2(0));
-        assertBuildStatusSuccess(p.scheduleBuild2(0));
-        assertBuildStatusSuccess(p.scheduleBuild2(0));
+        FreeStyleProject p = rule.createFreeStyleProject();
+        rule.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        rule.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        rule.assertBuildStatusSuccess(p.scheduleBuild2(0));
         assertEquals(3, p.getLastBuild().number);
         p.getBuildByNumber(2).setDisplayName("RC1");
         BuildSelector s = new SpecificBuildSelector("$NUM");
@@ -34,11 +42,12 @@ public class SpecificBuildSelectorTest extends HudsonTestCase {
         assertEquals(null, s.getBuild(p, new EnvVars("NUM", "RC2"), f, null));
     }
 
+    @Test
     public void testPermalink() throws Exception {
-        FreeStyleProject p = createFreeStyleProject();
-        assertBuildStatusSuccess(p.scheduleBuild2(0));
-        assertBuildStatusSuccess(p.scheduleBuild2(0));
-        assertBuildStatusSuccess(p.scheduleBuild2(0));
+        FreeStyleProject p = rule.createFreeStyleProject();
+        rule.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        rule.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        rule.assertBuildStatusSuccess(p.scheduleBuild2(0));
         assertEquals(3, p.getLastBuild().number);
         BuildSelector s = new SpecificBuildSelector("$NUM");
         BuildFilter f = new BuildFilter();

--- a/src/test/java/hudson/plugins/copyartifact/TriggeredBuildSelectorTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/TriggeredBuildSelectorTest.java
@@ -736,7 +736,7 @@ public class TriggeredBuildSelectorTest {
         assertEquals("upstreamValue1,upstreamValue1", getDownstreamAfterOverlappingFlow(true));
     }
 
-    @Bug(18804)
+    @Issue("JENKINS-18804")
     @Test
     public void testUpstreamWasRemoved() throws Exception {
         // upstream -> downstream
@@ -883,7 +883,7 @@ public class TriggeredBuildSelectorTest {
         }
     }
     
-    @Bug(14653)
+    @Issue("JENKINS-14653")
     @Test
     public void testMavenModule() throws Exception {
         ToolInstallations.configureDefaultMaven();

--- a/src/test/java/hudson/plugins/copyartifact/TriggeredBuildSelectorTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/TriggeredBuildSelectorTest.java
@@ -26,6 +26,7 @@ package hudson.plugins.copyartifact;
 
 import static org.junit.Assert.*;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.io.File;
 import org.apache.commons.io.FileUtils;
@@ -46,11 +47,8 @@ import hudson.tasks.BuildTrigger;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.Bug;
-import org.jvnet.hudson.test.ExtractResourceSCM;
-import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.*;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
-import org.jvnet.hudson.test.SleepBuilder;
 
 /**
  * Tests for {@link TriggeredBuildSelector}.
@@ -888,8 +886,8 @@ public class TriggeredBuildSelectorTest {
     @Bug(14653)
     @Test
     public void testMavenModule() throws Exception {
-        j.configureDefaultMaven();
-        MavenModuleSet upstream = j.createMavenProject();
+        ToolInstallations.configureDefaultMaven();
+        MavenModuleSet upstream = createMavenProject();
         FreeStyleProject downstream = j.createFreeStyleProject();
         
         upstream.setGoals("clean package");
@@ -926,4 +924,16 @@ public class TriggeredBuildSelectorTest {
                 b.getWorkspace().child("org.jvnet.hudson.main.test.multimod/moduleB/1.0-SNAPSHOT/moduleB-1.0-SNAPSHOT.jar").exists()
         );
     }
+
+    /**
+     * Creates an empty Maven project with an unique name.
+     *
+     * @return an empty Maven project with an unique name.
+     */
+    private MavenModuleSet createMavenProject() throws IOException {
+        MavenModuleSet mavenModuleSet = j.jenkins.createProject(MavenModuleSet.class, "test"+j.jenkins.getItems().size());
+        mavenModuleSet.setRunHeadless(true);
+        return mavenModuleSet;
+    }
+
 }

--- a/src/test/java/hudson/plugins/copyartifact/TriggeredBuildSelectorTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/TriggeredBuildSelectorTest.java
@@ -47,8 +47,12 @@ import hudson.tasks.BuildTrigger;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.*;
+import org.jvnet.hudson.test.ExtractResourceSCM;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
+import org.jvnet.hudson.test.SleepBuilder;
+import org.jvnet.hudson.test.ToolInstallations;
 
 /**
  * Tests for {@link TriggeredBuildSelector}.


### PR DESCRIPTION
[JENKINS-33389](https://issues.jenkins-ci.org/browse/JENKINS-33389)

* [x] Adapt to new parent POM
* [x] Adapt to split JTH.
* [x] Fix javadocs for Java 8
* [x] Correct line breaks in modified files
* [x] Migrate tests from `HudsonTestCase` to `JenkinsRule`.
* [x] Check PCT scenario against 1.642.3

@reviewbybees