### PR TITLE
[JENKINS-33389] Added notes about PermGen issue with Java7.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+Copy Artifact Plugin
+====================
+
+See https://wiki.jenkins-ci.org/display/JENKINS/Copy+Artifact+Plugin
+
+Notes for development
+---------------------
+
+* When running tests with Java < 8
+    * You will see `OutOfMemoryError: PermGen space.` when running tests.
+    * set `set MAVEN_OPTS=-XX:MaxPermSize=128m` to avoid that error.
+    * You never see this issue with Java 8, as Java 8 no longer have PermGen spaces.
+    


### PR DESCRIPTION
[JENKINS-33389](https://issues.jenkins-ci.org/browse/JENKINS-33389)

Introducing JTH >= 2.0 consuming more PermGen spaces, and requires extend it with `-XX:MaxPermSize=128m`.