### PR TITLE
[JENKINS-36314] Tests failing after SECURITY-170

### DIFF
--- a/src/test/java/hudson/plugins/copyartifact/CopyArtifactTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/CopyArtifactTest.java
@@ -353,7 +353,7 @@ public class CopyArtifactTest {
         ParameterDefinition paramDef3 = new StringParameterDefinition("TARGET","foo","");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef, paramDef2,paramDef3);
         p.addProperty(paramsDef);
-        CopyArtifactPermissionProperty cpp=new CopyArtifactPermissionProperty("/"+p.getName());
+        CopyArtifactPermissionProperty cpp = new CopyArtifactPermissionProperty("/"+p.getName());
         other.addProperty(cpp);
         rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause(),
@@ -611,7 +611,7 @@ public class CopyArtifactTest {
         ParameterDefinition paramDef = new StringParameterDefinition("FOO","foo");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
         other.addProperty(paramsDef);
-        CopyArtifactPermissionProperty cpp=new CopyArtifactPermissionProperty("/"+p.getName());
+        CopyArtifactPermissionProperty cpp = new CopyArtifactPermissionProperty("/"+p.getName());
         other.addProperty(cpp);
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(other.getName(),
                 null, new SavedBuildSelector(), "*.txt", "", false, false, true));
@@ -634,7 +634,7 @@ public class CopyArtifactTest {
         ParameterDefinition paramDef = new StringParameterDefinition("FOO","foo");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
         other.addProperty(paramsDef);
-        CopyArtifactPermissionProperty cpp=new CopyArtifactPermissionProperty("/"+p.getName());
+        CopyArtifactPermissionProperty cpp = new CopyArtifactPermissionProperty("/"+p.getName());
         other.addProperty(cpp);
         SpecificBuildSelector sbs = new SpecificBuildSelector("1");
         assertEquals("1", sbs.getBuildNumber());
@@ -659,7 +659,7 @@ public class CopyArtifactTest {
         other.addProperty(paramsDef);
         ParametersDefinitionProperty paramsDef2 = new ParametersDefinitionProperty(paramDef2);
         p.addProperty(paramsDef2);
-        CopyArtifactPermissionProperty cpp=new CopyArtifactPermissionProperty("/"+p.getName());
+        CopyArtifactPermissionProperty cpp = new CopyArtifactPermissionProperty("/"+p.getName());
         other.addProperty(cpp);
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(other.getName(),
                 null, new SpecificBuildSelector("$BAR"), "*.txt", "", false, false, true));
@@ -684,7 +684,7 @@ public class CopyArtifactTest {
         ParameterDefinition paramDef = new StringParameterDefinition("FOO","foo");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
         other.addProperty(paramsDef);
-        CopyArtifactPermissionProperty cpp=new CopyArtifactPermissionProperty("/"+p.getName());
+        CopyArtifactPermissionProperty cpp = new CopyArtifactPermissionProperty("/"+p.getName());
         other.addProperty(cpp);
         ParameterizedBuildSelector pbs = new ParameterizedBuildSelector("PBS");
         assertEquals("PBS", pbs.getParameterName());
@@ -709,7 +709,7 @@ public class CopyArtifactTest {
         ParameterDefinition paramDef = new StringParameterDefinition("FOO","foo");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
         other.addProperty(paramsDef);
-        CopyArtifactPermissionProperty cpp=new CopyArtifactPermissionProperty("/"+p.getName());
+        CopyArtifactPermissionProperty cpp = new CopyArtifactPermissionProperty("/"+p.getName());
         other.addProperty(cpp);
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(other.getName(),
                 null, new PermalinkBuildSelector("lastStableBuild"), "*.txt", "", false, false, true));

--- a/src/test/java/hudson/plugins/copyartifact/CopyArtifactTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/CopyArtifactTest.java
@@ -353,7 +353,7 @@ public class CopyArtifactTest {
         ParameterDefinition paramDef3 = new StringParameterDefinition("TARGET","foo","");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef, paramDef2,paramDef3);
         p.addProperty(paramsDef);
-        CopyArtifactPermissionProperty cpp = new CopyArtifactPermissionProperty("/"+p.getName());
+        CopyArtifactPermissionProperty cpp = new CopyArtifactPermissionProperty(p.getFullName());
         other.addProperty(cpp);
         rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause(),
@@ -611,7 +611,7 @@ public class CopyArtifactTest {
         ParameterDefinition paramDef = new StringParameterDefinition("FOO","foo");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
         other.addProperty(paramsDef);
-        CopyArtifactPermissionProperty cpp = new CopyArtifactPermissionProperty("/"+p.getName());
+        CopyArtifactPermissionProperty cpp = new CopyArtifactPermissionProperty(p.getFullName());
         other.addProperty(cpp);
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(other.getName(),
                 null, new SavedBuildSelector(), "*.txt", "", false, false, true));
@@ -634,7 +634,7 @@ public class CopyArtifactTest {
         ParameterDefinition paramDef = new StringParameterDefinition("FOO","foo");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
         other.addProperty(paramsDef);
-        CopyArtifactPermissionProperty cpp = new CopyArtifactPermissionProperty("/"+p.getName());
+        CopyArtifactPermissionProperty cpp = new CopyArtifactPermissionProperty(p.getFullName());
         other.addProperty(cpp);
         SpecificBuildSelector sbs = new SpecificBuildSelector("1");
         assertEquals("1", sbs.getBuildNumber());
@@ -659,7 +659,7 @@ public class CopyArtifactTest {
         other.addProperty(paramsDef);
         ParametersDefinitionProperty paramsDef2 = new ParametersDefinitionProperty(paramDef2);
         p.addProperty(paramsDef2);
-        CopyArtifactPermissionProperty cpp = new CopyArtifactPermissionProperty("/"+p.getName());
+        CopyArtifactPermissionProperty cpp = new CopyArtifactPermissionProperty(p.getFullName());
         other.addProperty(cpp);
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(other.getName(),
                 null, new SpecificBuildSelector("$BAR"), "*.txt", "", false, false, true));
@@ -684,7 +684,7 @@ public class CopyArtifactTest {
         ParameterDefinition paramDef = new StringParameterDefinition("FOO","foo");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
         other.addProperty(paramsDef);
-        CopyArtifactPermissionProperty cpp = new CopyArtifactPermissionProperty("/"+p.getName());
+        CopyArtifactPermissionProperty cpp = new CopyArtifactPermissionProperty(p.getFullName());
         other.addProperty(cpp);
         ParameterizedBuildSelector pbs = new ParameterizedBuildSelector("PBS");
         assertEquals("PBS", pbs.getParameterName());
@@ -709,7 +709,7 @@ public class CopyArtifactTest {
         ParameterDefinition paramDef = new StringParameterDefinition("FOO","foo");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
         other.addProperty(paramsDef);
-        CopyArtifactPermissionProperty cpp = new CopyArtifactPermissionProperty("/"+p.getName());
+        CopyArtifactPermissionProperty cpp = new CopyArtifactPermissionProperty(p.getFullName());
         other.addProperty(cpp);
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(other.getName(),
                 null, new PermalinkBuildSelector("lastStableBuild"), "*.txt", "", false, false, true));

--- a/src/test/java/hudson/plugins/copyartifact/CopyArtifactTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/CopyArtifactTest.java
@@ -353,8 +353,6 @@ public class CopyArtifactTest {
         ParameterDefinition paramDef3 = new StringParameterDefinition("TARGET","foo","");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef, paramDef2,paramDef3);
         p.addProperty(paramsDef);
-        CopyArtifactPermissionProperty cpp = new CopyArtifactPermissionProperty(p.getFullName());
-        other.addProperty(cpp);
         rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause(),
                 new ParametersAction(new StringParameterValue("PROJSRC", other.getName()),
@@ -611,8 +609,6 @@ public class CopyArtifactTest {
         ParameterDefinition paramDef = new StringParameterDefinition("FOO","foo");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
         other.addProperty(paramsDef);
-        CopyArtifactPermissionProperty cpp = new CopyArtifactPermissionProperty(p.getFullName());
-        other.addProperty(cpp);
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(other.getName(),
                 null, new SavedBuildSelector(), "*.txt", "", false, false, true));
         FreeStyleBuild b = other.scheduleBuild2(0, new UserCause(),
@@ -634,8 +630,6 @@ public class CopyArtifactTest {
         ParameterDefinition paramDef = new StringParameterDefinition("FOO","foo");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
         other.addProperty(paramsDef);
-        CopyArtifactPermissionProperty cpp = new CopyArtifactPermissionProperty(p.getFullName());
-        other.addProperty(cpp);
         SpecificBuildSelector sbs = new SpecificBuildSelector("1");
         assertEquals("1", sbs.getBuildNumber());
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(other.getName(), null, sbs, "*.txt", "", false, false, true));
@@ -659,8 +653,6 @@ public class CopyArtifactTest {
         other.addProperty(paramsDef);
         ParametersDefinitionProperty paramsDef2 = new ParametersDefinitionProperty(paramDef2);
         p.addProperty(paramsDef2);
-        CopyArtifactPermissionProperty cpp = new CopyArtifactPermissionProperty(p.getFullName());
-        other.addProperty(cpp);
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(other.getName(),
                 null, new SpecificBuildSelector("$BAR"), "*.txt", "", false, false, true));
         rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause(),
@@ -684,8 +676,6 @@ public class CopyArtifactTest {
         ParameterDefinition paramDef = new StringParameterDefinition("FOO","foo");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
         other.addProperty(paramsDef);
-        CopyArtifactPermissionProperty cpp = new CopyArtifactPermissionProperty(p.getFullName());
-        other.addProperty(cpp);
         ParameterizedBuildSelector pbs = new ParameterizedBuildSelector("PBS");
         assertEquals("PBS", pbs.getParameterName());
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(other.getName(), null, pbs, "*.txt", "", false, false, true));
@@ -709,8 +699,6 @@ public class CopyArtifactTest {
         ParameterDefinition paramDef = new StringParameterDefinition("FOO","foo");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
         other.addProperty(paramsDef);
-        CopyArtifactPermissionProperty cpp = new CopyArtifactPermissionProperty(p.getFullName());
-        other.addProperty(cpp);
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(other.getName(),
                 null, new PermalinkBuildSelector("lastStableBuild"), "*.txt", "", false, false, true));
         FreeStyleBuild b = other.scheduleBuild2(0, new UserCause(),

--- a/src/test/java/hudson/plugins/copyartifact/CopyArtifactTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/CopyArtifactTest.java
@@ -348,10 +348,10 @@ public class CopyArtifactTest {
         FreeStyleProject other = createArtifactProject(),
                          p = createProject("$PROJSRC", null, "$BASE/*.txt", "$TARGET/bar",
                                            false, false, false, true);
-        ParameterDefinition paramDef = new StringParameterDefinition("PROJSRC",other.getName(), "");
-        ParameterDefinition paramDef2 = new StringParameterDefinition("BASE","","");
-        ParameterDefinition paramDef3 = new StringParameterDefinition("TARGET","foo","");
-        ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef, paramDef2,paramDef3);
+        ParameterDefinition paramDef = new StringParameterDefinition("PROJSRC", other.getName(), "");
+        ParameterDefinition paramDef2 = new StringParameterDefinition("BASE", "", "");
+        ParameterDefinition paramDef3 = new StringParameterDefinition("TARGET", "foo", "");
+        ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef, paramDef2, paramDef3);
         p.addProperty(paramsDef);
         rule.assertBuildStatusSuccess(other.scheduleBuild2(0, new UserCause()).get());
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause(),
@@ -606,7 +606,7 @@ public class CopyArtifactTest {
     public void testSavedBuildSelector() throws Exception {
         FreeStyleProject other = createArtifactProject(),
                          p = rule.createFreeStyleProject();
-        ParameterDefinition paramDef = new StringParameterDefinition("FOO","foo");
+        ParameterDefinition paramDef = new StringParameterDefinition("FOO", "foo");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
         other.addProperty(paramsDef);
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(other.getName(),
@@ -627,7 +627,7 @@ public class CopyArtifactTest {
     public void testSpecificBuildSelector() throws Exception {
         FreeStyleProject other = createArtifactProject(),
                          p = rule.createFreeStyleProject();
-        ParameterDefinition paramDef = new StringParameterDefinition("FOO","foo");
+        ParameterDefinition paramDef = new StringParameterDefinition("FOO", "foo");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
         other.addProperty(paramsDef);
         SpecificBuildSelector sbs = new SpecificBuildSelector("1");
@@ -647,8 +647,8 @@ public class CopyArtifactTest {
     public void testSpecificBuildSelectorParameter() throws Exception {
         FreeStyleProject other = createArtifactProject(),
                          p = rule.createFreeStyleProject();
-        ParameterDefinition paramDef = new StringParameterDefinition("FOO","foo");
-        ParameterDefinition paramDef2 = new StringParameterDefinition("BAR","1");
+        ParameterDefinition paramDef = new StringParameterDefinition("FOO", "foo");
+        ParameterDefinition paramDef2 = new StringParameterDefinition("BAR", "1");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
         other.addProperty(paramsDef);
         ParametersDefinitionProperty paramsDef2 = new ParametersDefinitionProperty(paramDef2);
@@ -670,10 +670,10 @@ public class CopyArtifactTest {
     public void testParameterizedBuildSelector() throws Exception {
         FreeStyleProject other = createArtifactProject(),
                          p = rule.createFreeStyleProject();
-        ParameterDefinition pParamDef = new StringParameterDefinition("PBS","foo");
+        ParameterDefinition pParamDef = new StringParameterDefinition("PBS", "foo");
         ParametersDefinitionProperty pParamsDef = new ParametersDefinitionProperty(pParamDef);
         p.addProperty(pParamsDef);
-        ParameterDefinition paramDef = new StringParameterDefinition("FOO","foo");
+        ParameterDefinition paramDef = new StringParameterDefinition("FOO", "foo");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
         other.addProperty(paramsDef);
         ParameterizedBuildSelector pbs = new ParameterizedBuildSelector("PBS");
@@ -696,7 +696,7 @@ public class CopyArtifactTest {
     public void testPermalinkBuildSelector() throws Exception {
         FreeStyleProject other = createArtifactProject(),
                          p = rule.createFreeStyleProject();
-        ParameterDefinition paramDef = new StringParameterDefinition("FOO","foo");
+        ParameterDefinition paramDef = new StringParameterDefinition("FOO", "foo");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
         other.addProperty(paramsDef);
         p.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(other.getName(),
@@ -963,7 +963,7 @@ public class CopyArtifactTest {
     @Test
     public void testPermissionWhenParameterized() throws Exception {
         FreeStyleProject p = createProject("test$JOB", null, "", "", false, false, false, true);
-        ParameterDefinition paramDef = new StringParameterDefinition("JOB","job1");
+        ParameterDefinition paramDef = new StringParameterDefinition("JOB", "job1");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
         p.addProperty(paramsDef);
         // Build step should succeed when this parameter expands to a job accessible
@@ -994,7 +994,7 @@ public class CopyArtifactTest {
         if (new VersionNumber("1.406").isNewerThan(Hudson.getVersion())) return; // Skip
 
         FreeStyleProject p = createProject("testMatrix/FOO=$FOO", null, "", "", false, false, false, true);
-        ParameterDefinition paramDef = new StringParameterDefinition("FOO","FOO");
+        ParameterDefinition paramDef = new StringParameterDefinition("FOO", "FOO");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
         p.addProperty(paramsDef);
         // Build step should succeed when this parameter expands to a job accessible to
@@ -1017,7 +1017,7 @@ public class CopyArtifactTest {
         rule.assertBuildStatusSuccess(mp.scheduleBuild2(0, new UserCause()).get());
         FreeStyleProject p = createProject(mp.getName() + "/org.jvnet.hudson.main.test.multimod$FOO",
                                            null, "", "", false, false, false, true);
-        ParameterDefinition paramDef = new StringParameterDefinition("FOO","foo");
+        ParameterDefinition paramDef = new StringParameterDefinition("FOO", "foo");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
         p.addProperty(paramsDef);
         // Build step should succeed when this parameter expands to a job accessible to

--- a/src/test/java/hudson/plugins/copyartifact/CopyArtifactTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/CopyArtifactTest.java
@@ -346,7 +346,7 @@ public class CopyArtifactTest {
     @Test
     public void testParameters() throws Exception {
         FreeStyleProject other = createArtifactProject(),
-                         p = createProject("${PROJSRC}", null, "${BASE}/*.txt", "${TARGET}/bar",
+                         p = createProject("$PROJSRC", null, "$BASE/*.txt", "$TARGET/bar",
                                            false, false, false, true);
         ParameterDefinition paramDef = new StringParameterDefinition("PROJSRC",other.getName(), "");
         ParameterDefinition paramDef2 = new StringParameterDefinition("BASE","","");
@@ -963,11 +963,11 @@ public class CopyArtifactTest {
     @Test
     public void testPermissionWhenParameterized() throws Exception {
         FreeStyleProject p = createProject("test$JOB", null, "", "", false, false, false, true);
-        // Build step should succeed when this parameter expands to a job accessible
-        // to authenticated users (even if triggered by anonymous, as in this case):
         ParameterDefinition paramDef = new StringParameterDefinition("JOB","job1");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
         p.addProperty(paramsDef);
+        // Build step should succeed when this parameter expands to a job accessible
+        // to authenticated users (even if triggered by anonymous, as in this case):
         SecurityContextHolder.clearContext();
         FreeStyleBuild b = p.scheduleBuild2(0, new UserCause(),
                 new ParametersAction(new StringParameterValue("JOB", "Job2"))).get();

--- a/src/test/java/hudson/plugins/copyartifact/ParameterizedBuildSelectorTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/ParameterizedBuildSelectorTest.java
@@ -97,13 +97,12 @@ public class ParameterizedBuildSelectorTest {
     @Test
     public void testWorkflow() throws Exception {
         // Prepare an artifact to be copied.
-        WorkflowJob copier = createWorkflowJob();
         FreeStyleProject copiee = j.createFreeStyleProject();
         copiee.getBuildersList().add(new FileWriteBuilder("artifact.txt", "foobar"));
         copiee.getPublishersList().add(new ArtifactArchiver("artifact.txt"));
-        // Allow next project to copy from this
         j.assertBuildStatusSuccess(copiee.scheduleBuild2(0));
 
+        WorkflowJob copier = createWorkflowJob();
         ParameterDefinition pwParamDef = new StringParameterDefinition("SELECTOR","<StatusBuildSelector><stable>true</stable></StatusBuildSelector>");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(pwParamDef);
         copier.addProperty(paramsDef);
@@ -234,13 +233,12 @@ public class ParameterizedBuildSelectorTest {
     @Test
     public void testImmediateValue() throws Exception {
         // Prepare an artifact to be copied.
-        WorkflowJob copier = createWorkflowJob();
         FreeStyleProject copiee = j.createFreeStyleProject();
         copiee.getBuildersList().add(new FileWriteBuilder("artifact.txt", "foobar"));
         copiee.getPublishersList().add(new ArtifactArchiver("artifact.txt"));
-        // Allow next project to copy from this
         j.assertBuildStatusSuccess(copiee.scheduleBuild2(0));
 
+        WorkflowJob copier = createWorkflowJob();
         ParameterDefinition pwParamDef = new StringParameterDefinition("SELECTOR","<StatusBuildSelector><stable>true</stable></StatusBuildSelector>");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(pwParamDef);
         copier.addProperty(paramsDef);
@@ -284,10 +282,9 @@ public class ParameterizedBuildSelectorTest {
         FreeStyleProject copiee = j.createFreeStyleProject();
         copiee.getBuildersList().add(new FileWriteBuilder("artifact.txt", "foobar"));
         copiee.getPublishersList().add(new ArtifactArchiver("artifact.txt"));
-        // Allow next project to copy from this
         j.assertBuildStatusSuccess(copiee.scheduleBuild2(0));
         
-        FreeStyleProject copier = j.createFreeStyleProject("copier");
+        FreeStyleProject copier = j.createFreeStyleProject();
         ParameterDefinition pwParamDef = new StringParameterDefinition("SELECTOR","<StatusBuildSelector><stable>true</stable></StatusBuildSelector>");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(pwParamDef);
         copier.addProperty(paramsDef);

--- a/src/test/java/hudson/plugins/copyartifact/ParameterizedBuildSelectorTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/ParameterizedBuildSelectorTest.java
@@ -24,13 +24,17 @@
 
 package hudson.plugins.copyartifact;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
-import java.util.Random;
 
-import hudson.model.*;
-import hudson.security.Permission;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.ParameterDefinition;
+import hudson.model.ParametersAction;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.StringParameterDefinition;
+import hudson.model.StringParameterValue;
 import jenkins.util.VirtualFile;
 import hudson.plugins.copyartifact.testutils.CopyArtifactUtil;
 import hudson.plugins.copyartifact.testutils.FileWriteBuilder;
@@ -44,6 +48,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+
 
 /**
  * Tests for {@link ParameterizedBuildSelector}

--- a/src/test/java/hudson/plugins/copyartifact/ParameterizedBuildSelectorTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/ParameterizedBuildSelectorTest.java
@@ -103,8 +103,8 @@ public class ParameterizedBuildSelectorTest {
         j.assertBuildStatusSuccess(copiee.scheduleBuild2(0));
 
         WorkflowJob copier = createWorkflowJob();
-        ParameterDefinition pwParamDef = new StringParameterDefinition("SELECTOR","<StatusBuildSelector><stable>true</stable></StatusBuildSelector>");
-        ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(pwParamDef);
+        ParameterDefinition paramDef = new StringParameterDefinition("SELECTOR", "<StatusBuildSelector><stable>true</stable></StatusBuildSelector>");
+        ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
         copier.addProperty(paramsDef);
         copier.setDefinition(new CpsFlowDefinition(
             String.format(
@@ -239,8 +239,8 @@ public class ParameterizedBuildSelectorTest {
         j.assertBuildStatusSuccess(copiee.scheduleBuild2(0));
 
         WorkflowJob copier = createWorkflowJob();
-        ParameterDefinition pwParamDef = new StringParameterDefinition("SELECTOR","<StatusBuildSelector><stable>true</stable></StatusBuildSelector>");
-        ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(pwParamDef);
+        ParameterDefinition paramDef = new StringParameterDefinition("SELECTOR", "<StatusBuildSelector><stable>true</stable></StatusBuildSelector>");
+        ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
         copier.addProperty(paramsDef);
         copier.setDefinition(new CpsFlowDefinition(
             String.format(
@@ -285,8 +285,8 @@ public class ParameterizedBuildSelectorTest {
         j.assertBuildStatusSuccess(copiee.scheduleBuild2(0));
         
         FreeStyleProject copier = j.createFreeStyleProject();
-        ParameterDefinition pwParamDef = new StringParameterDefinition("SELECTOR","<StatusBuildSelector><stable>true</stable></StatusBuildSelector>");
-        ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(pwParamDef);
+        ParameterDefinition paramDef = new StringParameterDefinition("SELECTOR", "<StatusBuildSelector><stable>true</stable></StatusBuildSelector>");
+        ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
         copier.addProperty(paramsDef);
         ParameterizedBuildSelector pbs = new ParameterizedBuildSelector("${SELECTOR}");
         copier.getBuildersList().add(CopyArtifactUtil.createCopyArtifact(

--- a/src/test/java/hudson/plugins/copyartifact/ParameterizedBuildSelectorTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/ParameterizedBuildSelectorTest.java
@@ -103,8 +103,6 @@ public class ParameterizedBuildSelectorTest {
         copiee.getBuildersList().add(new FileWriteBuilder("artifact.txt", "foobar"));
         copiee.getPublishersList().add(new ArtifactArchiver("artifact.txt"));
         // Allow next project to copy from this
-        CopyArtifactPermissionProperty cpp = new CopyArtifactPermissionProperty(copier.getFullName());
-        copiee.addProperty(cpp);
         j.assertBuildStatusSuccess(copiee.scheduleBuild2(0));
 
         ParameterDefinition pwParamDef = new StringParameterDefinition("SELECTOR","<StatusBuildSelector><stable>true</stable></StatusBuildSelector>");
@@ -242,8 +240,6 @@ public class ParameterizedBuildSelectorTest {
         copiee.getBuildersList().add(new FileWriteBuilder("artifact.txt", "foobar"));
         copiee.getPublishersList().add(new ArtifactArchiver("artifact.txt"));
         // Allow next project to copy from this
-        CopyArtifactPermissionProperty cpp = new CopyArtifactPermissionProperty(copier.getFullName());
-        copiee.addProperty(cpp);
         j.assertBuildStatusSuccess(copiee.scheduleBuild2(0));
 
         ParameterDefinition pwParamDef = new StringParameterDefinition("SELECTOR","<StatusBuildSelector><stable>true</stable></StatusBuildSelector>");
@@ -290,8 +286,6 @@ public class ParameterizedBuildSelectorTest {
         copiee.getBuildersList().add(new FileWriteBuilder("artifact.txt", "foobar"));
         copiee.getPublishersList().add(new ArtifactArchiver("artifact.txt"));
         // Allow next project to copy from this
-        CopyArtifactPermissionProperty cpp = new CopyArtifactPermissionProperty("/copier");
-        copiee.addProperty(cpp);
         j.assertBuildStatusSuccess(copiee.scheduleBuild2(0));
         
         FreeStyleProject copier = j.createFreeStyleProject("copier");

--- a/src/test/java/hudson/plugins/copyartifact/ParameterizedBuildSelectorTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/ParameterizedBuildSelectorTest.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 
+import jenkins.util.VirtualFile;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.ParameterDefinition;
@@ -35,7 +36,6 @@ import hudson.model.ParametersAction;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.StringParameterDefinition;
 import hudson.model.StringParameterValue;
-import jenkins.util.VirtualFile;
 import hudson.plugins.copyartifact.testutils.CopyArtifactUtil;
 import hudson.plugins.copyartifact.testutils.FileWriteBuilder;
 import hudson.tasks.ArtifactArchiver;
@@ -48,7 +48,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-
 
 /**
  * Tests for {@link ParameterizedBuildSelector}

--- a/src/test/java/hudson/plugins/copyartifact/ParameterizedBuildSelectorTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/ParameterizedBuildSelectorTest.java
@@ -103,7 +103,7 @@ public class ParameterizedBuildSelectorTest {
         copiee.getBuildersList().add(new FileWriteBuilder("artifact.txt", "foobar"));
         copiee.getPublishersList().add(new ArtifactArchiver("artifact.txt"));
         // Allow next project to copy from this
-        CopyArtifactPermissionProperty cpp = new CopyArtifactPermissionProperty("/"+copier.getName());
+        CopyArtifactPermissionProperty cpp = new CopyArtifactPermissionProperty(copier.getFullName());
         copiee.addProperty(cpp);
         j.assertBuildStatusSuccess(copiee.scheduleBuild2(0));
 
@@ -242,7 +242,7 @@ public class ParameterizedBuildSelectorTest {
         copiee.getBuildersList().add(new FileWriteBuilder("artifact.txt", "foobar"));
         copiee.getPublishersList().add(new ArtifactArchiver("artifact.txt"));
         // Allow next project to copy from this
-        CopyArtifactPermissionProperty cpp = new CopyArtifactPermissionProperty("/"+copier.getName());
+        CopyArtifactPermissionProperty cpp = new CopyArtifactPermissionProperty(copier.getFullName());
         copiee.addProperty(cpp);
         j.assertBuildStatusSuccess(copiee.scheduleBuild2(0));
 

--- a/src/test/java/hudson/plugins/copyartifact/ParameterizedBuildSelectorTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/ParameterizedBuildSelectorTest.java
@@ -103,7 +103,7 @@ public class ParameterizedBuildSelectorTest {
         copiee.getBuildersList().add(new FileWriteBuilder("artifact.txt", "foobar"));
         copiee.getPublishersList().add(new ArtifactArchiver("artifact.txt"));
         // Allow next project to copy from this
-        CopyArtifactPermissionProperty cpp=new CopyArtifactPermissionProperty("/"+copier.getName());
+        CopyArtifactPermissionProperty cpp = new CopyArtifactPermissionProperty("/"+copier.getName());
         copiee.addProperty(cpp);
         j.assertBuildStatusSuccess(copiee.scheduleBuild2(0));
 
@@ -242,7 +242,7 @@ public class ParameterizedBuildSelectorTest {
         copiee.getBuildersList().add(new FileWriteBuilder("artifact.txt", "foobar"));
         copiee.getPublishersList().add(new ArtifactArchiver("artifact.txt"));
         // Allow next project to copy from this
-        CopyArtifactPermissionProperty cpp=new CopyArtifactPermissionProperty("/"+copier.getName());
+        CopyArtifactPermissionProperty cpp = new CopyArtifactPermissionProperty("/"+copier.getName());
         copiee.addProperty(cpp);
         j.assertBuildStatusSuccess(copiee.scheduleBuild2(0));
 
@@ -290,7 +290,7 @@ public class ParameterizedBuildSelectorTest {
         copiee.getBuildersList().add(new FileWriteBuilder("artifact.txt", "foobar"));
         copiee.getPublishersList().add(new ArtifactArchiver("artifact.txt"));
         // Allow next project to copy from this
-        CopyArtifactPermissionProperty cpp=new CopyArtifactPermissionProperty("/copier");
+        CopyArtifactPermissionProperty cpp = new CopyArtifactPermissionProperty("/copier");
         copiee.addProperty(cpp);
         j.assertBuildStatusSuccess(copiee.scheduleBuild2(0));
         

--- a/src/test/java/hudson/plugins/copyartifact/TriggeredBuildSelectorTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/TriggeredBuildSelectorTest.java
@@ -189,7 +189,7 @@ public class TriggeredBuildSelectorTest {
     @Test
     public void testUseOldest() throws Exception {
         FreeStyleProject upstream = j.createFreeStyleProject();
-        ParameterDefinition paramDef = new StringParameterDefinition("CONTENT","foo");
+        ParameterDefinition paramDef = new StringParameterDefinition("CONTENT", "foo");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
         upstream.addProperty(paramsDef);
         FreeStyleProject downstream = j.createFreeStyleProject();
@@ -241,7 +241,7 @@ public class TriggeredBuildSelectorTest {
         d.setGlobalUpstreamFilterStrategy(TriggeredBuildSelector.UpstreamFilterStrategy.UseOldest);
         
         FreeStyleProject upstream = j.createFreeStyleProject();
-        ParameterDefinition paramDef = new StringParameterDefinition("CONTENT","foo");
+        ParameterDefinition paramDef = new StringParameterDefinition("CONTENT", "foo");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
         upstream.addProperty(paramsDef);
         FreeStyleProject downstream = j.createFreeStyleProject();
@@ -291,7 +291,7 @@ public class TriggeredBuildSelectorTest {
     @Test
     public void testUseNewest() throws Exception {
         FreeStyleProject upstream = j.createFreeStyleProject();
-        ParameterDefinition paramDef = new StringParameterDefinition("CONTENT","foo");
+        ParameterDefinition paramDef = new StringParameterDefinition("CONTENT", "foo");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
         upstream.addProperty(paramsDef);
         FreeStyleProject downstream = j.createFreeStyleProject();
@@ -343,7 +343,7 @@ public class TriggeredBuildSelectorTest {
         d.setGlobalUpstreamFilterStrategy(TriggeredBuildSelector.UpstreamFilterStrategy.UseNewest);
         
         FreeStyleProject upstream = j.createFreeStyleProject();
-        ParameterDefinition paramDef = new StringParameterDefinition("CONTENT","foo");
+        ParameterDefinition paramDef = new StringParameterDefinition("CONTENT", "foo");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
         upstream.addProperty(paramsDef);
         FreeStyleProject downstream = j.createFreeStyleProject();
@@ -393,7 +393,7 @@ public class TriggeredBuildSelectorTest {
     @Test
     public void testUseOldestNested() throws Exception {
         FreeStyleProject upstream = j.createFreeStyleProject();
-        ParameterDefinition paramDef = new StringParameterDefinition("CONTENT","foo");
+        ParameterDefinition paramDef = new StringParameterDefinition("CONTENT", "foo");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
         upstream.addProperty(paramsDef);
         FreeStyleProject intermediate1 = j.createFreeStyleProject();
@@ -483,7 +483,7 @@ public class TriggeredBuildSelectorTest {
     @Test
     public void testUseNewestNested() throws Exception {
         FreeStyleProject upstream = j.createFreeStyleProject();
-        ParameterDefinition paramDef = new StringParameterDefinition("CONTENT","foo");
+        ParameterDefinition paramDef = new StringParameterDefinition("CONTENT", "foo");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
         upstream.addProperty(paramsDef);
         FreeStyleProject intermediate1 = j.createFreeStyleProject();
@@ -576,7 +576,7 @@ public class TriggeredBuildSelectorTest {
         d.setGlobalUpstreamFilterStrategy(TriggeredBuildSelector.UpstreamFilterStrategy.UseOldest);
         
         FreeStyleProject upstream = j.createFreeStyleProject();
-        ParameterDefinition paramDef = new StringParameterDefinition("CONTENT","foo");
+        ParameterDefinition paramDef = new StringParameterDefinition("CONTENT", "foo");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
         upstream.addProperty(paramsDef);
         FreeStyleProject downstream = j.createFreeStyleProject();
@@ -671,7 +671,7 @@ public class TriggeredBuildSelectorTest {
         //
 
         FreeStyleProject upstream = j.createFreeStyleProject("upstream");
-        ParameterDefinition paramDef = new StringParameterDefinition("CONTENT","foo");
+        ParameterDefinition paramDef = new StringParameterDefinition("CONTENT", "foo");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
         upstream.addProperty(paramsDef);
         FreeStyleProject intermediate = j.createFreeStyleProject("intermediate");

--- a/src/test/java/hudson/plugins/copyartifact/TriggeredBuildSelectorTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/TriggeredBuildSelectorTest.java
@@ -24,13 +24,25 @@
 
 package hudson.plugins.copyartifact;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.io.File;
 
-import hudson.model.*;
+import hudson.model.Cause;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.ParameterDefinition;
+import hudson.model.ParametersAction;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.Result;
+import hudson.model.StringParameterDefinition;
+import hudson.model.StringParameterValue;
 import org.apache.commons.io.FileUtils;
 
 import hudson.Util;

--- a/src/test/java/hudson/plugins/copyartifact/TriggeredBuildSelectorTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/TriggeredBuildSelectorTest.java
@@ -46,8 +46,6 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Result;
 import hudson.model.StringParameterDefinition;
-
-
 import hudson.plugins.copyartifact.testutils.CopyArtifactUtil;
 import hudson.plugins.copyartifact.testutils.FileWriteBuilder;
 import hudson.plugins.copyartifact.testutils.RemoveUpstreamBuilder;
@@ -398,7 +396,6 @@ public class TriggeredBuildSelectorTest {
         ParameterDefinition paramDef = new StringParameterDefinition("CONTENT","foo");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
         upstream.addProperty(paramsDef);
-
         FreeStyleProject intermediate1 = j.createFreeStyleProject();
         FreeStyleProject intermediate2 = j.createFreeStyleProject();
         FreeStyleProject downstream = j.createFreeStyleProject();
@@ -677,7 +674,6 @@ public class TriggeredBuildSelectorTest {
         ParameterDefinition paramDef = new StringParameterDefinition("CONTENT","foo");
         ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
         upstream.addProperty(paramsDef);
-
         FreeStyleProject intermediate = j.createFreeStyleProject("intermediate");
         FreeStyleProject downstream = j.createFreeStyleProject("downstream");
 

--- a/src/test/java/hudson/plugins/copyartifact/TriggeredBuildSelectorTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/TriggeredBuildSelectorTest.java
@@ -29,16 +29,12 @@ import static org.junit.Assert.*;
 import java.io.IOException;
 import java.util.Arrays;
 import java.io.File;
+
+import hudson.model.*;
 import org.apache.commons.io.FileUtils;
 
 import hudson.Util;
 import hudson.maven.MavenModuleSet;
-import hudson.model.Cause;
-import hudson.model.FreeStyleProject;
-import hudson.model.ParametersAction;
-import hudson.model.StringParameterValue;
-import hudson.model.FreeStyleBuild;
-import hudson.model.Result;
 import hudson.plugins.copyartifact.testutils.CopyArtifactUtil;
 import hudson.plugins.copyartifact.testutils.FileWriteBuilder;
 import hudson.plugins.copyartifact.testutils.RemoveUpstreamBuilder;
@@ -182,6 +178,9 @@ public class TriggeredBuildSelectorTest {
     @Test
     public void testUseOldest() throws Exception {
         FreeStyleProject upstream = j.createFreeStyleProject();
+        ParameterDefinition paramDef = new StringParameterDefinition("CONTENT","foo");
+        ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
+        upstream.addProperty(paramsDef);
         FreeStyleProject downstream = j.createFreeStyleProject();
         
         upstream.getBuildersList().add(new FileWriteBuilder("artifact.txt", "${CONTENT}"));
@@ -231,6 +230,9 @@ public class TriggeredBuildSelectorTest {
         d.setGlobalUpstreamFilterStrategy(TriggeredBuildSelector.UpstreamFilterStrategy.UseOldest);
         
         FreeStyleProject upstream = j.createFreeStyleProject();
+        ParameterDefinition paramDef = new StringParameterDefinition("CONTENT","foo");
+        ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
+        upstream.addProperty(paramsDef);
         FreeStyleProject downstream = j.createFreeStyleProject();
         
         upstream.getBuildersList().add(new FileWriteBuilder("artifact.txt", "${CONTENT}"));
@@ -278,6 +280,9 @@ public class TriggeredBuildSelectorTest {
     @Test
     public void testUseNewest() throws Exception {
         FreeStyleProject upstream = j.createFreeStyleProject();
+        ParameterDefinition paramDef = new StringParameterDefinition("CONTENT","foo");
+        ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
+        upstream.addProperty(paramsDef);
         FreeStyleProject downstream = j.createFreeStyleProject();
         
         upstream.getBuildersList().add(new FileWriteBuilder("artifact.txt", "${CONTENT}"));
@@ -327,6 +332,9 @@ public class TriggeredBuildSelectorTest {
         d.setGlobalUpstreamFilterStrategy(TriggeredBuildSelector.UpstreamFilterStrategy.UseNewest);
         
         FreeStyleProject upstream = j.createFreeStyleProject();
+        ParameterDefinition paramDef = new StringParameterDefinition("CONTENT","foo");
+        ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
+        upstream.addProperty(paramsDef);
         FreeStyleProject downstream = j.createFreeStyleProject();
         
         upstream.getBuildersList().add(new FileWriteBuilder("artifact.txt", "${CONTENT}"));
@@ -374,6 +382,10 @@ public class TriggeredBuildSelectorTest {
     @Test
     public void testUseOldestNested() throws Exception {
         FreeStyleProject upstream = j.createFreeStyleProject();
+        ParameterDefinition paramDef = new StringParameterDefinition("CONTENT","foo");
+        ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
+        upstream.addProperty(paramsDef);
+
         FreeStyleProject intermediate1 = j.createFreeStyleProject();
         FreeStyleProject intermediate2 = j.createFreeStyleProject();
         FreeStyleProject downstream = j.createFreeStyleProject();
@@ -461,6 +473,9 @@ public class TriggeredBuildSelectorTest {
     @Test
     public void testUseNewestNested() throws Exception {
         FreeStyleProject upstream = j.createFreeStyleProject();
+        ParameterDefinition paramDef = new StringParameterDefinition("CONTENT","foo");
+        ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
+        upstream.addProperty(paramsDef);
         FreeStyleProject intermediate1 = j.createFreeStyleProject();
         FreeStyleProject intermediate2 = j.createFreeStyleProject();
         FreeStyleProject downstream = j.createFreeStyleProject();
@@ -551,6 +566,9 @@ public class TriggeredBuildSelectorTest {
         d.setGlobalUpstreamFilterStrategy(TriggeredBuildSelector.UpstreamFilterStrategy.UseOldest);
         
         FreeStyleProject upstream = j.createFreeStyleProject();
+        ParameterDefinition paramDef = new StringParameterDefinition("CONTENT","foo");
+        ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
+        upstream.addProperty(paramsDef);
         FreeStyleProject downstream = j.createFreeStyleProject();
         
         upstream.getBuildersList().add(new FileWriteBuilder("artifact.txt", "${CONTENT}"));
@@ -643,6 +661,10 @@ public class TriggeredBuildSelectorTest {
         //
 
         FreeStyleProject upstream = j.createFreeStyleProject("upstream");
+        ParameterDefinition paramDef = new StringParameterDefinition("CONTENT","foo");
+        ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(paramDef);
+        upstream.addProperty(paramsDef);
+
         FreeStyleProject intermediate = j.createFreeStyleProject("intermediate");
         FreeStyleProject downstream = j.createFreeStyleProject("downstream");
 

--- a/src/test/java/hudson/plugins/copyartifact/TriggeredBuildSelectorTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/TriggeredBuildSelectorTest.java
@@ -33,20 +33,21 @@ import static org.junit.Assert.assertNull;
 import java.io.IOException;
 import java.util.Arrays;
 import java.io.File;
-
-import hudson.model.Cause;
-import hudson.model.FreeStyleBuild;
-import hudson.model.FreeStyleProject;
-import hudson.model.ParameterDefinition;
-import hudson.model.ParametersAction;
-import hudson.model.ParametersDefinitionProperty;
-import hudson.model.Result;
-import hudson.model.StringParameterDefinition;
-import hudson.model.StringParameterValue;
 import org.apache.commons.io.FileUtils;
 
 import hudson.Util;
 import hudson.maven.MavenModuleSet;
+import hudson.model.Cause;
+import hudson.model.FreeStyleProject;
+import hudson.model.ParameterDefinition;
+import hudson.model.ParametersAction;
+import hudson.model.StringParameterValue;
+import hudson.model.FreeStyleBuild;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.Result;
+import hudson.model.StringParameterDefinition;
+
+
 import hudson.plugins.copyartifact.testutils.CopyArtifactUtil;
 import hudson.plugins.copyartifact.testutils.FileWriteBuilder;
 import hudson.plugins.copyartifact.testutils.RemoveUpstreamBuilder;


### PR DESCRIPTION
[JENKINS-36314](https://issues.jenkins-ci.org/browse/JENKINS-36314?jql=project%20%3D%20JENKINS%20AND%20status%20in%20(Open%2C%20%22In%20Progress%22%2C%20Reopened)%20AND%20component%20%3D%20copyartifact-plugin%20AND%20text%20~%20%22SECURITY-170%22)

After SECURITY-170 parameterized jobs does not accept unknown build params as default, this PR explicitly sets the build params and copy permissions for the jobs used in the tests.

@reviewbybees 