### PR TITLE
[JENKINS-32832] symlink fails to be created as the directory is not created.

### DIFF
--- a/src/main/java/hudson/plugins/copyartifact/FingerprintingCopyMethod.java
+++ b/src/main/java/hudson/plugins/copyartifact/FingerprintingCopyMethod.java
@@ -73,6 +73,7 @@ public class FingerprintingCopyMethod extends Copier {
     public void copyOne(FilePath s, FilePath d, boolean fingerprintArtifacts) throws IOException, InterruptedException {
         String link = s.readLink();
         if (link != null) {
+            d.getParent().mkdirs();
             d.symlinkTo(link, /* TODO Copier signature does not offer a TaskListener; anyway this is rarely used */TaskListener.NULL);
             return;
         }


### PR DESCRIPTION
[JENKINS-32832](https://issues.jenkins-ci.org/browse/JENKINS-32832)

When a symlink is in a sub directory, it may fail to be created as its parent directory is not created yet.
