### PR TITLE
[JENKINS-46700] symbol support for better pipeline compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,11 @@
           </exclusion>
         </exclusions>
       </dependency>
+      <dependency>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>structs</artifactId>
+          <version>1.2</version>
+      </dependency>
       <!-- Used for UI test -->
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>

--- a/src/main/java/hudson/plugins/copyartifact/CopyArtifact.java
+++ b/src/main/java/hudson/plugins/copyartifact/CopyArtifact.java
@@ -68,6 +68,7 @@ import org.acegisecurity.Authentication;
 import org.acegisecurity.GrantedAuthority;
 import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -573,7 +574,7 @@ public class CopyArtifact extends Builder implements SimpleBuildStep {
         return expected.equals(expanded);
     }
     
-    @Extension
+    @Extension @Symbol("copyArtifacts")
     public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
 
         public FormValidation doCheckProjectName(

--- a/src/main/java/hudson/plugins/copyartifact/DownstreamBuildSelector.java
+++ b/src/main/java/hudson/plugins/copyartifact/DownstreamBuildSelector.java
@@ -30,6 +30,7 @@ import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
@@ -178,7 +179,7 @@ public class DownstreamBuildSelector extends BuildSelector {
         return false;
     }
     
-    @Extension
+    @Extension @Symbol("downstream")
     public static final class DescriptorImpl extends Descriptor<BuildSelector> {
         @Override
         public String getDisplayName() {

--- a/src/main/java/hudson/plugins/copyartifact/LastCompletedBuildSelector.java
+++ b/src/main/java/hudson/plugins/copyartifact/LastCompletedBuildSelector.java
@@ -28,6 +28,8 @@ import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.model.Result;
 import hudson.model.Run;
+import jenkins.model.Jenkins;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -44,8 +46,17 @@ public class LastCompletedBuildSelector extends BuildSelector {
         return true;
     }
 
-    @Extension
-    public static final Descriptor<BuildSelector> DESCRIPTOR =
-            new SimpleBuildSelectorDescriptor(
-                LastCompletedBuildSelector.class, Messages._LastCompletedBuildSelector_DisplayName());
+    /**
+     * @deprecated
+     *      here for backward compatibility. Get it from {@link Jenkins#getDescriptor(Class)}
+     */
+    public static /*almost final*/ Descriptor<BuildSelector> DESCRIPTOR;
+
+    @Extension @Symbol("lastCompleted")
+    public static final class DescriptorImpl extends SimpleBuildSelectorDescriptor {
+        public DescriptorImpl() {
+            super(LastCompletedBuildSelector.class, Messages._LastCompletedBuildSelector_DisplayName());
+            DESCRIPTOR = this;
+        }
+    }
 }

--- a/src/main/java/hudson/plugins/copyartifact/ParameterizedBuildSelector.java
+++ b/src/main/java/hudson/plugins/copyartifact/ParameterizedBuildSelector.java
@@ -32,7 +32,9 @@ import hudson.model.Descriptor;
 import hudson.model.Job;
 import hudson.model.Run;
 
+import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -102,8 +104,17 @@ public class ParameterizedBuildSelector extends BuildSelector {
         return xml;
     }
 
-    @Extension(ordinal=-20)
-    public static final Descriptor<BuildSelector> DESCRIPTOR =
-            new SimpleBuildSelectorDescriptor(
-                ParameterizedBuildSelector.class, Messages._ParameterizedBuildSelector_DisplayName());
+    /**
+     * @deprecated
+     *      here for backward compatibility. Get it from {@link Jenkins#getDescriptor(Class)}
+     */
+    public static /*almost final*/ Descriptor<BuildSelector> DESCRIPTOR;
+
+    @Extension(ordinal=-20) @Symbol("buildParameter")
+    public static final class DescriptorImpl extends SimpleBuildSelectorDescriptor {
+        public DescriptorImpl() {
+            super(ParameterizedBuildSelector.class, Messages._ParameterizedBuildSelector_DisplayName());
+            DESCRIPTOR = this;
+        }
+    }
 }

--- a/src/main/java/hudson/plugins/copyartifact/PermalinkBuildSelector.java
+++ b/src/main/java/hudson/plugins/copyartifact/PermalinkBuildSelector.java
@@ -32,6 +32,7 @@ import hudson.model.PermalinkProjectAction.Permalink;
 import hudson.model.Run;
 import hudson.util.ComboBoxModel;
 import jenkins.model.Jenkins;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
@@ -57,7 +58,7 @@ public class PermalinkBuildSelector extends BuildSelector {
         return (run != null && filter.isSelectable(run, env)) ? run : null;
     }
 
-    @Extension
+    @Extension @Symbol("permalink")
     public static class DescriptorImpl extends Descriptor<BuildSelector> {
         @Override
         public String getDisplayName() {

--- a/src/main/java/hudson/plugins/copyartifact/SavedBuildSelector.java
+++ b/src/main/java/hudson/plugins/copyartifact/SavedBuildSelector.java
@@ -27,6 +27,8 @@ import hudson.EnvVars;
 import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.model.Run;
+import jenkins.model.Jenkins;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -42,8 +44,17 @@ public class SavedBuildSelector extends BuildSelector {
         return run.isKeepLog();
     }
 
-    @Extension(ordinal=50)
-    public static final Descriptor<BuildSelector> DESCRIPTOR =
-            new SimpleBuildSelectorDescriptor(
-                SavedBuildSelector.class, Messages._SavedBuildSelector_DisplayName());
+    /**
+     * @deprecated
+     *      here for backward compatibility. Get it from {@link Jenkins#getDescriptor(Class)}
+     */
+    public static /*almost final*/ Descriptor<BuildSelector> DESCRIPTOR;
+
+    @Extension(ordinal=50) @Symbol("latestSavedBuild")
+    public static final class DescriptorImpl extends SimpleBuildSelectorDescriptor {
+        public DescriptorImpl() {
+            super(SavedBuildSelector.class, Messages._SavedBuildSelector_DisplayName());
+            DESCRIPTOR = this;
+        }
+    }
 }

--- a/src/main/java/hudson/plugins/copyartifact/SpecificBuildSelector.java
+++ b/src/main/java/hudson/plugins/copyartifact/SpecificBuildSelector.java
@@ -31,6 +31,9 @@ import hudson.model.PermalinkProjectAction;
 import hudson.model.Run;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import jenkins.model.Jenkins;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -94,8 +97,17 @@ public class SpecificBuildSelector extends BuildSelector {
         return run;
     }
 
-    @Extension(ordinal=-10)
-    public static final Descriptor<BuildSelector> DESCRIPTOR =
-            new SimpleBuildSelectorDescriptor(
-                SpecificBuildSelector.class, Messages._SpecificBuildSelector_DisplayName());
+    /**
+     * @deprecated
+     *      here for backward compatibility. Get it from {@link Jenkins#getDescriptor(Class)}
+     */
+    public static /*almost final*/ Descriptor<BuildSelector> DESCRIPTOR;
+
+    @Extension(ordinal=-10) @Symbol("specific")
+    public static final class DescriptorImpl extends SimpleBuildSelectorDescriptor {
+        public DescriptorImpl() {
+            super(SpecificBuildSelector.class, Messages._SpecificBuildSelector_DisplayName());
+            DESCRIPTOR = this;
+        }
+    }
 }

--- a/src/main/java/hudson/plugins/copyartifact/StatusBuildSelector.java
+++ b/src/main/java/hudson/plugins/copyartifact/StatusBuildSelector.java
@@ -28,7 +28,10 @@ import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.model.Result;
 import hudson.model.Run;
+import jenkins.model.Jenkins;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 /**
  * Copy artifacts from the latest successful or stable build.
@@ -37,10 +40,20 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class StatusBuildSelector extends BuildSelector {
     private Boolean stable;
 
-    @DataBoundConstructor
+    @Deprecated
     public StatusBuildSelector(boolean stable) {
+        setStable(stable);
+    }
+
+    @DataBoundConstructor
+    public StatusBuildSelector() {
+    }
+
+    @DataBoundSetter
+    public void setStable(boolean stable) {
         this.stable = stable ? Boolean.TRUE : null;
     }
+
 
     public boolean isStable() {
         return stable != null && stable.booleanValue();
@@ -51,8 +64,17 @@ public class StatusBuildSelector extends BuildSelector {
         return isBuildResultBetterOrEqualTo(run, isStable() ? Result.SUCCESS : Result.UNSTABLE);
     }
 
-    @Extension(ordinal=100)
-    public static final Descriptor<BuildSelector> DESCRIPTOR =
-            new SimpleBuildSelectorDescriptor(
-                StatusBuildSelector.class, Messages._StatusBuildSelector_DisplayName());
+    /**
+     * @deprecated
+     *      here for backward compatibility. Get it from {@link Jenkins#getDescriptor(Class)}
+     */
+    public static /*almost final*/ Descriptor<BuildSelector> DESCRIPTOR;
+
+    @Extension(ordinal=100) @Symbol("lastSuccessful")
+    public static final class DescriptorImpl extends SimpleBuildSelectorDescriptor {
+        public DescriptorImpl() {
+            super(StatusBuildSelector.class, Messages._StatusBuildSelector_DisplayName());
+            DESCRIPTOR = this;
+        }
+    }
 }

--- a/src/main/java/hudson/plugins/copyartifact/TriggeredBuildSelector.java
+++ b/src/main/java/hudson/plugins/copyartifact/TriggeredBuildSelector.java
@@ -41,6 +41,7 @@ import hudson.model.Job;
 import hudson.model.Run;
 import net.sf.json.JSONObject;
 
+import org.jenkinsci.Symbol;
 import org.jvnet.localizer.Localizable;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
@@ -218,7 +219,7 @@ public class TriggeredBuildSelector extends BuildSelector {
         return isFallbackToLastSuccessful() && isBuildResultBetterOrEqualTo(run, Result.SUCCESS);
     }
 
-    @Extension(ordinal=25)
+    @Extension(ordinal=25)  @Symbol("upstream")
     public static class DescriptorImpl extends SimpleBuildSelectorDescriptor {
         private UpstreamFilterStrategy globalUpstreamFilterStrategy;
         

--- a/src/main/java/hudson/plugins/copyartifact/WorkspaceSelector.java
+++ b/src/main/java/hudson/plugins/copyartifact/WorkspaceSelector.java
@@ -31,6 +31,10 @@ import hudson.model.Descriptor;
 import hudson.model.Run;
 import java.io.IOException;
 import java.io.PrintStream;
+
+import jenkins.model.Jenkins;
+import org.jenkinsci.Symbol;
+import org.jvnet.localizer.Localizable;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 /**
@@ -62,8 +66,17 @@ public class WorkspaceSelector extends BuildSelector {
         }
     }
 
-    @Extension(ordinal=-20)
-    public static final Descriptor<BuildSelector> DESCRIPTOR =
-            new SimpleBuildSelectorDescriptor(
-                WorkspaceSelector.class, Messages._WorkspaceSelector_DisplayName());
+    /**
+     * @deprecated
+     *      here for backward compatibility. Get it from {@link Jenkins#getDescriptor(Class)}
+     */
+    public static /*almost final*/ Descriptor<BuildSelector> DESCRIPTOR;
+
+    @Extension(ordinal=-20) @Symbol("workspace")
+    public static final class DescriptorImpl extends SimpleBuildSelectorDescriptor {
+        public DescriptorImpl() {
+            super(WorkspaceSelector.class, Messages._WorkspaceSelector_DisplayName());
+            DESCRIPTOR = this;
+        }
+    }
 }


### PR DESCRIPTION
See [the ticket](https://issues.jenkins-ci.org/browse/JENKINS-46700) for more details.

In order to allow symbol names on `BuildSelector` I had to turn them into fully-fledged class, since `@Symbol` cannot be placed on a field given the way it works.