### PR TITLE
[JENKINS-44496] Add description to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
     <artifactId>copyartifact</artifactId>
     <packaging>hpi</packaging>
     <name>Copy Artifact Plugin</name>
+    <description>Adds a build step to copy artifacts from another project.</description>
     <version>1.39-SNAPSHOT</version>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/Copy+Artifact+Plugin</url>
 


### PR DESCRIPTION
[JENKINS-44496](https://issues.jenkins-ci.org/browse/JENKINS-44496)

The latest update center displays description of pom.xml.

Copied description from resources/index.jelly: https://github.com/jenkinsci/copyartifact-plugin/blob/master/src/main/resources/index.jelly
