### PR TITLE
[JENKINS-47780] Rename the symbol for TriggeredBuildSelector to "triggered" (was "upstream")

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,19 @@
       <java.level>7</java.level>
     </properties>
 
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.jenkins-ci.tools</groupId>
+          <artifactId>maven-hpi-plugin</artifactId>
+          <configuration>
+            <!-- Renamed "upstream()" to "triggered()" -->
+            <compatibleSinceVersion>1.40</compatibleSinceVersion>
+          </configuration>
+        </plugin>
+      </plugins>
+    </build>
+
     <dependencies>
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>

--- a/src/main/java/hudson/plugins/copyartifact/TriggeredBuildSelector.java
+++ b/src/main/java/hudson/plugins/copyartifact/TriggeredBuildSelector.java
@@ -44,6 +44,7 @@ import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.jvnet.localizer.Localizable;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
 
 /**
@@ -95,21 +96,41 @@ public class TriggeredBuildSelector extends BuildSelector {
         }
     };
     private Boolean fallbackToLastSuccessful;
-    private final UpstreamFilterStrategy upstreamFilterStrategy;
+    private UpstreamFilterStrategy upstreamFilterStrategy;
     private boolean allowUpstreamDependencies;
 
     @DataBoundConstructor
+    public TriggeredBuildSelector() {
+        this(false);
+    }
+
+    /**
+     * @param fallbackToLastSuccessful {@code true} to fallback to the last successful build when no appropriate build is found.
+     * @param upstreamFilterStrategy strategy to pick the most appropriate upstream build.
+     * @param allowUpstreamDependencies {@code true} to scan upstream builds also using relation provided by fingerprints.
+     * @deprecated Use {@link #TriggeredBuildSelector()} instead.
+     */
+    @Deprecated
     public TriggeredBuildSelector(boolean fallbackToLastSuccessful, UpstreamFilterStrategy upstreamFilterStrategy, boolean allowUpstreamDependencies) {
-        this.fallbackToLastSuccessful = fallbackToLastSuccessful ? Boolean.TRUE : null;
-        this.upstreamFilterStrategy = upstreamFilterStrategy;
+        this.setFallbackToLastSuccessful(fallbackToLastSuccessful);
+        this.setUpstreamFilterStrategy(upstreamFilterStrategy);
         this.allowUpstreamDependencies = allowUpstreamDependencies;
     }
 
+    /**
+     * @param fallbackToLastSuccessful {@code true} to fallback to the last successful build when no appropriate build is found.
+     * @param upstreamFilterStrategy strategy to pick the most appropriate upstream build.
+     * @deprecated Use {@link #TriggeredBuildSelector()} instead.
+     */
     @Deprecated
     public TriggeredBuildSelector(boolean fallbackToLastSuccessful, UpstreamFilterStrategy upstreamFilterStrategy) {
         this(fallbackToLastSuccessful, upstreamFilterStrategy, false);
     }
 
+    /**
+     * @param fallback {@code true} to fallback to the last successful build when no appropriate build is found.
+     * @deprecated Use {@link #TriggeredBuildSelector()} instead.
+     */
     @Deprecated
     public TriggeredBuildSelector(boolean fallback) {
         this(fallback, UpstreamFilterStrategy.UseGlobalSetting, false);
@@ -120,10 +141,26 @@ public class TriggeredBuildSelector extends BuildSelector {
     }
     
     /**
+     * @param fallbackToLastSuccessful {@code true} to fallback to the last successful build when no appropriate build is found.
+     */
+    @DataBoundSetter
+    public void setFallbackToLastSuccessful(boolean fallbackToLastSuccessful) {
+        this.fallbackToLastSuccessful = fallbackToLastSuccessful ? Boolean.TRUE : null;
+    }
+
+    /**
      * @return Which build should be used if triggered by multiple upstream builds.
      */
     public UpstreamFilterStrategy getUpstreamFilterStrategy() {
         return upstreamFilterStrategy;
+    }
+
+    /**
+     * @param upstreamFilterStrategy strategy to pick the most appropriate upstream build.
+     */
+    @DataBoundSetter
+    public void setUpstreamFilterStrategy(UpstreamFilterStrategy upstreamFilterStrategy) {
+        this.upstreamFilterStrategy = upstreamFilterStrategy;
     }
 
     /**
@@ -152,6 +189,15 @@ public class TriggeredBuildSelector extends BuildSelector {
         return allowUpstreamDependencies;
     }
     
+
+    /**
+     * @param allowUpstreamDependencies {@code true} to scan upstream builds also using relation provided by fingerprints.
+     */
+    @DataBoundSetter
+    public void setAllowUpstreamDependencies(boolean allowUpstreamDependencies) {
+        this.allowUpstreamDependencies = allowUpstreamDependencies;
+    }
+
     @Override
     public Run<?,?> getBuild(Job<?,?> job, EnvVars env, BuildFilter filter, Run<?,?> parent) {
         Run<?,?> result = null;
@@ -219,7 +265,7 @@ public class TriggeredBuildSelector extends BuildSelector {
         return isFallbackToLastSuccessful() && isBuildResultBetterOrEqualTo(run, Result.SUCCESS);
     }
 
-    @Extension(ordinal=25)  @Symbol("upstream")
+    @Extension(ordinal=25)  @Symbol("triggered")
     public static class DescriptorImpl extends SimpleBuildSelectorDescriptor {
         private UpstreamFilterStrategy globalUpstreamFilterStrategy;
         

--- a/src/test/java/hudson/plugins/copyartifact/CopyArtifactWorkflowTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/CopyArtifactWorkflowTest.java
@@ -299,7 +299,7 @@ public class CopyArtifactWorkflowTest {
 
         WorkflowJob copier = jenkinsRule.createWorkflow(
             "copier",
-            "copyArtifacts(projectName: 'copiee', selector: upstream());"
+            "copyArtifacts(projectName: 'copiee', selector: triggered());"
             + "echo readFile('artifact.txt');"
         );
         jenkinsRule.assertBuildStatusSuccess(copiee.scheduleBuild2(0));


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-47780

copyartifact-1.39 introduced symbols for pipelines (#88), but it caused a problem.

copyartifact-1.39 uses "upstream" for `TriggeredBuildSelector`, but "upstream" is already used for the symbol of ReverseBuildTrigger  in Jenkins core:
https://github.com/jenkinsci/jenkins/blob/jenkins-2.73/core/src/main/java/jenkins/triggers/ReverseBuildTrigger.java#L192

workflow-cps usually decides the actual classes considering their contexts.
For example, when I declare like this,
```
copyArtifacts(projectName: "copiee", selector: upstream())
```
workflow-cps binds `upstream` to `BuildSelector` that is the type of the `selector` parameter.

But this looks not work for `triggers`.
```
pipeline {
    ...
    triggers {
        upstream (
            upstreamProjects: 'job1', threshold: hudson.model.Result.SUCCESS
        )
    }
   ...
```
Though apparently this `upstream` should be not `BuildSelector` but `BuildTrigger`, workflow-cps tries to resolve this `upstream` as `ReverseBuildTrigger`.

Installing copyartifact-1.39 cause `ReverseBuildTrigger` not work for declarative pipelines.

This request uses "triggered" instead of "upstream" for `TriggeredBuildSelector`.
