### PR TITLE
[FIXED JENKINS-47074] Support build ID in SpecificBuildSelector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,19 @@
       <tag>HEAD</tag>
   </scm>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <configuration>
+          <!-- JENKINS-47074: Build ID precedes display names. -->
+          <compatibleSinceVersion>1.40</compatibleSinceVersion>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>

--- a/src/main/resources/hudson/plugins/copyartifact/SpecificBuildSelector/help-buildNumber.html
+++ b/src/main/resources/hudson/plugins/copyartifact/SpecificBuildSelector/help-buildNumber.html
@@ -1,6 +1,6 @@
 <div>
   While this selector is for build numbers (e.g. "22" for build #22),
   you can also resolve build parameters or environment variables (e.g. "${PARAM}").
-  The display name of a build and permalinks (e.g. "lastSuccessfulBuild", "lastBuild"...)
+  Build IDs, display names and permalinks (e.g. "lastSuccessfulBuild", "lastBuild"...)
   can be used as well.
 </div>

--- a/src/test/java/hudson/plugins/copyartifact/CopyArtifactWorkflowTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/CopyArtifactWorkflowTest.java
@@ -260,7 +260,7 @@ public class CopyArtifactWorkflowTest {
     public void testSpecificBuildSelector() throws Exception {
         WorkflowJob copier = jenkinsRule.createWorkflow(
             "copier",
-            "copyArtifacts(projectName: 'copiee', selector: specific(\"${build('copiee').number}\"));"
+            "copyArtifacts(projectName: 'copiee', selector: specific(build('copiee').id));"
             + "echo readFile('artifact.txt');"
         );
         jenkinsRule.createWorkflow(

--- a/src/test/java/hudson/plugins/copyartifact/SpecificBuildSelectorTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/SpecificBuildSelectorTest.java
@@ -1,6 +1,7 @@
 package hudson.plugins.copyartifact;
 
 import hudson.EnvVars;
+import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import org.junit.Rule;
 import org.junit.Test;
@@ -59,4 +60,18 @@ public class SpecificBuildSelectorTest {
         assertEquals(p.getLastUnsuccessfulBuild(), s.getBuild(p, new EnvVars("NUM", "lastUnsuccessfulBuild"), f, null));
     }
 
+    @Issue("JENKINS-47074")
+    @Test
+    public void testBuildId() throws Exception {
+        FreeStyleProject p = rule.createFreeStyleProject();
+        FreeStyleBuild b1 = rule.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        FreeStyleBuild b2 = rule.assertBuildStatusSuccess(p.scheduleBuild2(0));
+
+        // Build ID precedes to display names.
+        b1.setDisplayName(b2.getId());
+        b2.setDisplayName(b1.getId());
+
+        assertEquals(b1, new SpecificBuildSelector(b1.getId()).getBuild(p, new EnvVars(), new BuildFilter(), null));
+        assertEquals(b2, new SpecificBuildSelector(b2.getId()).getBuild(p, new EnvVars(), new BuildFilter(), null));
+    }
 }


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-47074

It makes it easier to use SpecificBuildSelector in pipeline jobs like this:
* Before
    ```
    copyArtifacts(projectName: "fromJob", selector: specific("${build("fromJob").number}")
    ```
* After
    ```
    copyArtifacts(projectName: "fromJob", selector: specific("build("fromJob").id")
    ```
