### PR TITLE
[JENKINS-47074] Verify SpecificBuildSelector accepts build IDs

### DIFF
--- a/src/test/java/hudson/plugins/copyartifact/CopyArtifactWorkflowTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/CopyArtifactWorkflowTest.java
@@ -271,6 +271,23 @@ public class CopyArtifactWorkflowTest {
         jenkinsRule.assertLogContains("foobar", jenkinsRule.assertBuildStatusSuccess(copier.scheduleBuild2(0)));
     }
 
+    @Issue("JENKINS-47074")
+    @Test
+    public void testSpecificBuildSelectorWithId() throws Exception {
+        // build number == build id since Jenkins 1.597 (JENKINS-24380).
+        WorkflowJob copier = jenkinsRule.createWorkflow(
+            "copier",
+            "copyArtifacts(projectName: 'copiee', selector: specific(build('copiee').id));"
+            + "echo readFile('artifact.txt');"
+        );
+        jenkinsRule.createWorkflow(
+            "copiee",
+            "writeFile text: 'foobar', file: 'artifact.txt';"
+            + "archive includes: 'artifact.txt';"
+        );
+        jenkinsRule.assertLogContains("foobar", jenkinsRule.assertBuildStatusSuccess(copier.scheduleBuild2(0)));
+    }
+
     @Test
     public void testStatusBuildSelector() throws Exception {
         WorkflowJob copiee = jenkinsRule.createWorkflow(


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-47074

Jenkins 1.597+ uses the build number as the build ID, and `SpecificBuildSelector` should accept build IDs without any changes as @jglick pointed in https://github.com/jenkinsci/copyartifact-plugin/pull/101#issuecomment-373139068.