### PR TITLE
Add pipeline property copyArtifactPermission

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>cloudbees-folder</artifactId>
-        <version>4.0</version>
+        <version>5.16</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -102,6 +102,7 @@
         <artifactId>workflow-cps</artifactId>
         <version>2.32</version>
         <scope>test</scope>
+        <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -168,6 +169,11 @@
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>scm-api</artifactId>
         <version>2.0.8</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins.workflow</groupId>
+        <artifactId>workflow-multibranch</artifactId>
+        <version>2.10</version>
         <scope>test</scope>
       </dependency>
     </dependencies>

--- a/src/main/java/hudson/plugins/copyartifact/CopyArtifactPermissionProperty.java
+++ b/src/main/java/hudson/plugins/copyartifact/CopyArtifactPermissionProperty.java
@@ -53,6 +53,7 @@ import hudson.model.JobProperty;
 import hudson.model.JobPropertyDescriptor;
 import hudson.model.AbstractProject;
 import hudson.util.FormValidation;
+import org.jenkinsci.Symbol;
 
 /**
  *　Job Property to define projects that can copy artifacts of this project.
@@ -153,6 +154,7 @@ public class CopyArtifactPermissionProperty extends JobProperty<Job<?,?>> {
      * Descriptor for {@link CopyArtifactPermissionProperty}.
      */
     @Extension
+    @Symbol("copyArtifactPermission")
     public static class DescriptorImpl extends JobPropertyDescriptor {
         /**
          * @return name displayed in the project configuration page.

--- a/src/test/java/hudson/plugins/copyartifact/CopyArtifactPermissionPropertyTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/CopyArtifactPermissionPropertyTest.java
@@ -31,6 +31,7 @@ import hudson.matrix.MatrixConfiguration;
 import hudson.matrix.MatrixProject;
 import hudson.matrix.TextAxis;
 import hudson.model.FreeStyleProject;
+import hudson.model.JobProperty;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -42,6 +43,9 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import org.jvnet.hudson.test.MockFolder;
+
+import org.jenkinsci.plugins.workflow.cps.SnippetizerTester;
+import org.jenkinsci.plugins.workflow.multibranch.JobPropertyStep;
 
 /**
  * Tests for {@link CopyArtifactPermissionProperty}
@@ -269,6 +273,13 @@ public class CopyArtifactPermissionPropertyTest {
         assertEquals(Arrays.asList("../project1"), d.doAutoCompleteProjectNames("../p", child).getValues());
         assertEquals(Collections.emptyList(), d.doAutoCompleteProjectNames("x", freestyle).getValues());
         assertEquals(Collections.emptyList(), d.doAutoCompleteProjectNames("", freestyle).getValues());
+    }
+
+    @Test public void configProps() throws Exception {
+        JobProperty property = new CopyArtifactPermissionProperty("project1,project2");
+        SnippetizerTester tester = new SnippetizerTester(j);
+        tester.assertRoundTrip(new JobPropertyStep(Collections.singletonList(property)),
+                "properties([copyArtifactPermission('project1,project2')])" );
     }
 
     /**


### PR DESCRIPTION
Allows this in the options block

```
pipeline {
    agent any
    options {
        copyArtifactPermission('job1,...')
    }
    stages{...}
}
```
as discussed [here](https://groups.google.com/forum/#!topic/jenkinsci-dev/nJ54NaM7ctU)