### PR TITLE
copyArtifactPermission II

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>cloudbees-folder</artifactId>
-        <version>4.0</version>
+        <version>5.16</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -102,6 +102,7 @@
         <artifactId>workflow-cps</artifactId>
         <version>2.32</version>
         <scope>test</scope>
+        <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -168,6 +169,11 @@
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>scm-api</artifactId>
         <version>2.0.8</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins.workflow</groupId>
+        <artifactId>workflow-multibranch</artifactId>
+        <version>2.10</version>
         <scope>test</scope>
       </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
         <java.level>8</java.level>
         <workflow-api-plugin.version>2.28</workflow-api-plugin.version>
         <useBeta>true</useBeta>
+        <workflow-cps-plugin.version>2.32</workflow-cps-plugin.version>
     </properties>
 
     <dependencies>
@@ -76,7 +77,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>credentials</artifactId>
-        <version>1.24</version>
+        <version>2.1.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -100,9 +101,15 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-cps</artifactId>
-        <version>2.32</version>
+        <version>${workflow-cps-plugin.version}</version>
         <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins.workflow</groupId>
+        <artifactId>workflow-cps</artifactId>
+        <version>${workflow-cps-plugin.version}</version>
         <classifier>tests</classifier>
+        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/hudson/plugins/copyartifact/CopyArtifactPermissionProperty.java
+++ b/src/main/java/hudson/plugins/copyartifact/CopyArtifactPermissionProperty.java
@@ -53,6 +53,7 @@ import hudson.model.JobProperty;
 import hudson.model.JobPropertyDescriptor;
 import hudson.model.AbstractProject;
 import hudson.util.FormValidation;
+import org.jenkinsci.Symbol;
 
 /**
  *　Job Property to define projects that can copy artifacts of this project.
@@ -153,6 +154,7 @@ public class CopyArtifactPermissionProperty extends JobProperty<Job<?,?>> {
      * Descriptor for {@link CopyArtifactPermissionProperty}.
      */
     @Extension
+    @Symbol("copyArtifactPermission")
     public static class DescriptorImpl extends JobPropertyDescriptor {
         /**
          * @return name displayed in the project configuration page.

--- a/src/test/java/hudson/plugins/copyartifact/CopyArtifactPermissionPropertyTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/CopyArtifactPermissionPropertyTest.java
@@ -31,6 +31,7 @@ import hudson.matrix.MatrixConfiguration;
 import hudson.matrix.MatrixProject;
 import hudson.matrix.TextAxis;
 import hudson.model.FreeStyleProject;
+import hudson.model.JobProperty;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -42,6 +43,9 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import org.jvnet.hudson.test.MockFolder;
+
+import org.jenkinsci.plugins.workflow.cps.SnippetizerTester;
+import org.jenkinsci.plugins.workflow.multibranch.JobPropertyStep;
 
 /**
  * Tests for {@link CopyArtifactPermissionProperty}
@@ -269,6 +273,13 @@ public class CopyArtifactPermissionPropertyTest {
         assertEquals(Arrays.asList("../project1"), d.doAutoCompleteProjectNames("../p", child).getValues());
         assertEquals(Collections.emptyList(), d.doAutoCompleteProjectNames("x", freestyle).getValues());
         assertEquals(Collections.emptyList(), d.doAutoCompleteProjectNames("", freestyle).getValues());
+    }
+
+    @Test public void configProps() throws Exception {
+        JobProperty property = new CopyArtifactPermissionProperty("project1,project2");
+        SnippetizerTester tester = new SnippetizerTester(j);
+        tester.assertRoundTrip(new JobPropertyStep(Collections.singletonList(property)),
+                "properties([copyArtifactPermission('project1,project2')])" );
     }
 
     /**


### PR DESCRIPTION
Trying to fix up #105.

It took me a long time to get the new test to pass, and it turns out that this is because the conditions under which this feature are actually useful for Pipeline are so rarefied that it might as well not exist. It does not work if you are using a `QueueItemAuthenticator` like `authorize-project`—because if the build authentication lacks `READ` permission to upstream, [this line](https://github.com/jenkinsci/copyartifact-plugin/blob/3680ce8e6e2db2d19e66170d1cc44aa0c25d0b13/src/main/java/hudson/plugins/copyartifact/CopyArtifact.java#L411) returns null even though the project name is correct. It does not work if you simply specify the upstream project name as a string literal, since then [this line](https://github.com/jenkinsci/copyartifact-plugin/blob/3680ce8e6e2db2d19e66170d1cc44aa0c25d0b13/src/main/java/hudson/plugins/copyartifact/CopyArtifact.java#L412) will not match and `CopyArtifactPermissionProperty` is not even consulted. It does not work if you define a parameter for the upstream project name and then use Groovy interpolation to resolve that parameter value before passing it to the step, as is recommended for every other case where Pipeline scripts use parameters in steps. It does not work in the first build if you used the `properties` step to define the parameter, since you cannot use the `${params.UPSTREAM}` syntax via Groovy interpolation (as before), and [this line](https://github.com/jenkinsci/copyartifact-plugin/blob/3680ce8e6e2db2d19e66170d1cc44aa0c25d0b13/src/main/java/hudson/plugins/copyartifact/CopyArtifact.java#L396) will not match anything since there were no parameters defined when the build was scheduled and thus no `ParametersAction`. It _only_ works if you specifically decline to set per-build authentication, in which case it is unclear why [this code](https://github.com/jenkinsci/copyartifact-plugin/blob/3680ce8e6e2db2d19e66170d1cc44aa0c25d0b13/src/main/java/hudson/plugins/copyartifact/CopyArtifact.java#L490-L498) even exists, and if you predefined the parameter (not an option for multibranch projects), and if you used a freestyle-like parameter reference rather than the standard Pipeline idioms.