### PR TITLE
Restructure and expand Project Name documentation

### DIFF
--- a/src/main/resources/hudson/plugins/copyartifact/CopyArtifact/help-projectName.html
+++ b/src/main/resources/hudson/plugins/copyartifact/CopyArtifact/help-projectName.html
@@ -1,20 +1,40 @@
-<div>
-  Name of source project for copying of artifact(s).
-  <p/>
-  If a Maven project is specified, artifacts from all of its modules will be copied.
-  Enter <tt>JOBNAME/MODULENAME</tt> here to copy from a particular module; you may
-  copy/paste this from the URL for that module when browsing Jenkins.
-  Example: <tt>MyMavenJob/my.group$MyModule</tt>
-  <p/>
-  If a multiconfiguration (matrix) project is specified, artifacts from all of its
-  configurations will be copied, each into a subdirectory with the name of the
-  configuration as seen in its URL when browsing Jenkins.
-  Example: If target directory is given as <tt>fromMatrix</tt> then the copy could
-  create <tt>$WORKSPACE/fromMatrix/label=slaveA/dist/mybuild.jar</tt> and
-  <tt>$WORKSPACE/fromMatrix/label=slaveB/dist/mybuild.jar</tt>. <br/>
-  To copy from a particular configuration, enter <tt>JOBNAME/AXIS=VALUE,..</tt> as
-  seen in the URL for that configuration. Example: <tt>MyMatrixJob/jdk=Java6u17</tt>
-  <br/>  To copy artifacts from one matrix project to another, use a parameter to
-  select the matching configuration in the source project.
-  Example: <tt>OtherMatrixJob/jdk=$jdk</tt>
-</div>
+<p>The name of the project to copy artifacts from.</p>
+<dl>
+  <dt><strong>Maven projects:</strong></dt>
+  <dd>
+    <p>
+      Artifacts from all modules will be copied.
+      Enter <tt>JOBNAME/MODULENAME</tt> here to copy from a particular module; you may
+      copy/paste this from the URL for that module when browsing Jenkins.<br />
+      <strong>Example:</strong> <tt>MyMavenJob/my.group$MyModule</tt>
+    </p>
+  </dd>
+  <dt><strong>Matrix projects:</strong></dt>
+  <dd>
+    <p>
+      Artifacts from all configurations will be copied, each into a subdirectory
+      with the name of the configuration as seen in its URL when browsing Jenkins.<br />
+      <strong>Example:</strong> If the target directory is given as <tt>fromMatrix</tt>
+      then the copy could create <tt>$WORKSPACE/fromMatrix/label=slaveA/dist/mybuild.jar</tt>
+      and <tt>$WORKSPACE/fromMatrix/label=slaveB/dist/mybuild.jar</tt>.
+    </p>
+    <p>
+      To copy from a particular configuration, enter <tt>JOBNAME/AXIS=VALUE,..</tt> as
+      seen in the URL for that configuration.<br />
+      <strong>Example:</strong> <tt>MyMatrixJob/jdk=Java6u17</tt>
+    </p>
+    <p>
+      To copy artifacts from one matrix project to another, use a parameter to
+      select the matching configuration in the source project.<br />
+      <strong>Example:</strong> <tt>OtherMatrixJob/jdk=$jdk</tt>
+    </p>
+  </dd>
+  <dt><strong>Multibranch Pipeline projects:</strong></dt>
+  <dd>
+    <p>
+      Use an absolute path consisting of the project name followed by the branch name.<br />
+      <strong>Example:</strong> <tt>/MyMultibranchProject/MyBranch</tt>
+    </p>
+  </dd>
+</ul>
+<p>See the wiki page <a href="https://wiki.jenkins.io/display/JENKINS/How+to+reference+another+project+by+name">"How to reference another project by name"</a> for more information.</p> 

--- a/src/main/resources/hudson/plugins/copyartifact/CopyArtifact/help-projectName.html
+++ b/src/main/resources/hudson/plugins/copyartifact/CopyArtifact/help-projectName.html
@@ -32,8 +32,13 @@
   <dt><strong>Multibranch Pipeline projects:</strong></dt>
   <dd>
     <p>
-      Use an absolute path consisting of the project name followed by the branch name.<br />
+      Use an path consisting of the project name followed by the branch name.<br />
       <strong>Example:</strong> <tt>/MyMultibranchProject/MyBranch</tt>
+    </p>
+    <p>
+      Special letters like '/' in branch names should be escaped.
+      You can see the exact name in "Full project name" in job pages of each branch.<br />
+      <strong>Example:</strong> <tt>../MyMultibranchProject/feature%2Fnavigation</tt>
     </p>
   </dd>
 </ul>

--- a/src/main/resources/hudson/plugins/copyartifact/CopyArtifact/help-projectName.html
+++ b/src/main/resources/hudson/plugins/copyartifact/CopyArtifact/help-projectName.html
@@ -32,7 +32,7 @@
   <dt><strong>Multibranch Pipeline projects:</strong></dt>
   <dd>
     <p>
-      Use an path consisting of the project name followed by the branch name.<br />
+      Use a path consisting of the project name followed by the branch name.<br />
       <strong>Example:</strong> <tt>/MyMultibranchProject/MyBranch</tt>
     </p>
     <p>


### PR DESCRIPTION
- Split into a section for each type of project, for improved clarity
- Add syntax for Multibranch Pipeline projects (as mentioned on https://issues.jenkins-ci.org/browse/JENKINS-40429#comment-343463)