### PR TITLE
Java 11: make sure the plugin builds fine both on JDK 8 and JDK 11

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.0-beta-3</version>
+    <version>1.0-beta-7</version>
   </extension>
 </extensions>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin()
+buildPlugin(configurations: buildPlugin.recommendedConfigurations())

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.15</version>
+        <version>3.40</version>
         <relativePath />
     </parent>
 
@@ -163,7 +163,6 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>1.9.5</version>
         <scope>test</scope>
         <exclusions>
             <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -28,9 +28,9 @@
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.121.1</jenkins.version>
         <java.level>8</java.level>
-        <workflow-api-plugin.version>2.28</workflow-api-plugin.version>
+        <workflow-api-plugin.version>2.33</workflow-api-plugin.version>
         <useBeta>true</useBeta>
-        <workflow-cps-plugin.version>2.32</workflow-cps-plugin.version>
+        <workflow-cps-plugin.version>2.63</workflow-cps-plugin.version>
     </properties>
 
     <dependencies>
@@ -43,7 +43,7 @@
       <dependency>
           <groupId>org.jenkins-ci.plugins</groupId>
           <artifactId>structs</artifactId>
-          <version>1.14</version>
+          <version>1.17</version>
       </dependency>
       <dependency>
           <groupId>org.jenkins-ci.plugins</groupId>
@@ -120,13 +120,13 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-step-api</artifactId>
-        <version>2.13</version>
+        <version>2.19</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-support</artifactId>
-        <version>2.14</version>
+        <version>3.2</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -174,7 +174,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>scm-api</artifactId>
-        <version>2.0.8</version>
+        <version>2.2.6</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -183,6 +183,17 @@
         <scope>test</scope>
       </dependency>
     </dependencies>
+
+    <dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>commons-net</groupId>
+          <artifactId>commons-net</artifactId>
+          <version>3.6</version>
+        </dependency>
+      </dependencies>
+    </dependencyManagement>
+
     <reporting>
       <plugins>
         <plugin>

--- a/src/test/java/hudson/plugins/copyartifact/CopyArtifactTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/CopyArtifactTest.java
@@ -462,7 +462,7 @@ public class CopyArtifactTest {
     private MavenModuleSet setupMavenJob() throws Exception {
         ToolInstallations.configureDefaultMaven();
         MavenModuleSet mp = createMavenProject();
-        mp.setGoals("clean package");
+        mp.setGoals("clean package -Dmaven.compiler.source=1.8 -Dmaven.compiler.target=1.8");
         mp.setScm(new ExtractResourceSCM(getClass().getResource("maven-job.zip")));
         return mp;
     }

--- a/src/test/java/hudson/plugins/copyartifact/TriggeredBuildSelectorTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/TriggeredBuildSelectorTest.java
@@ -925,7 +925,7 @@ public class TriggeredBuildSelectorTest {
         MavenModuleSet upstream = createMavenProject();
         FreeStyleProject downstream = j.createFreeStyleProject();
         
-        upstream.setGoals("clean package");
+        upstream.setGoals("clean package -Dmaven.compiler.source=1.8 -Dmaven.compiler.target=1.8");
         upstream.setScm(new ExtractResourceSCM(getClass().getResource("maven-job.zip")));
         upstream.getPublishersList().add(new BuildTrigger(downstream.getName(), Result.SUCCESS));
         


### PR DESCRIPTION
For Java 11 readiness, apply recommended configuration:
https://wiki.jenkins.io/display/JENKINS/Java+11+Developer+Guidelines#Java11DeveloperGuidelines-MakesureyourpluginistestedinContinuousIntegrationonJava8andJava11atthesametime

And fixing what was revealed through this.

