### PR TITLE
Minimal changes to pass tests on Java11

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.0-beta-3</version>
+    <version>1.0-beta-7</version>
   </extension>
 </extensions>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin()
+buildPlugin(configurations: buildPlugin.recommendedConfigurations())

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.15</version>
+        <version>3.43</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.121.1</jenkins.version>
         <java.level>8</java.level>
-        <workflow-api-plugin.version>2.28</workflow-api-plugin.version>
+        <workflow-api-plugin.version>2.30</workflow-api-plugin.version>
         <useBeta>true</useBeta>
         <workflow-cps-plugin.version>2.32</workflow-cps-plugin.version>
     </properties>
@@ -95,6 +95,12 @@
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
+        <artifactId>workflow-support</artifactId>
+        <version>3.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-job</artifactId>
         <version>2.11.2</version>
         <scope>test</scope>
@@ -128,12 +134,6 @@
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-step-api</artifactId>
         <version>2.13</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins.workflow</groupId>
-        <artifactId>workflow-support</artifactId>
-        <version>2.14</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -182,7 +182,8 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>scm-api</artifactId>
-        <version>2.0.8</version>
+        <version>2.2.6</version>
+        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,13 @@
         <artifactId>maven-plugin</artifactId>
         <version>3.1.2</version>
         <optional>true</optional>
+        <exclusions>
+            <exclusion>
+                <!-- to avoid RequireUpperBoundDeps with jenkins-test-harness -->
+                <groupId>commons-net</groupId>
+                <artifactId>commons-net</artifactId>
+            </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
           <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/test/java/hudson/plugins/copyartifact/CopyArtifactTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/CopyArtifactTest.java
@@ -462,7 +462,7 @@ public class CopyArtifactTest {
     private MavenModuleSet setupMavenJob() throws Exception {
         ToolInstallations.configureDefaultMaven();
         MavenModuleSet mp = createMavenProject();
-        mp.setGoals("clean package");
+        mp.setGoals("clean package -Dmaven.compiler.source=1.8 -Dmaven.compiler.target=1.8");
         mp.setScm(new ExtractResourceSCM(getClass().getResource("maven-job.zip")));
         return mp;
     }

--- a/src/test/java/hudson/plugins/copyartifact/TriggeredBuildSelectorTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/TriggeredBuildSelectorTest.java
@@ -925,7 +925,7 @@ public class TriggeredBuildSelectorTest {
         MavenModuleSet upstream = createMavenProject();
         FreeStyleProject downstream = j.createFreeStyleProject();
         
-        upstream.setGoals("clean package");
+        upstream.setGoals("clean package -Dmaven.compiler.source=1.8 -Dmaven.compiler.target=1.8");
         upstream.setScm(new ExtractResourceSCM(getClass().getResource("maven-job.zip")));
         upstream.getPublishersList().add(new BuildTrigger(downstream.getName(), Result.SUCCESS));
         


### PR DESCRIPTION
Replaces #110.

I plan a micro release for Java11 and want minimum changes as possible, least dependency changes in the plugin.
And it’s more clear what is mandatory to make applicable to Java11.
