### PR TITLE
Remove use of deprecated CLI constructor

### DIFF
--- a/src/test/java/hudson/plugins/copyartifact/BuildSelectorParameterTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/BuildSelectorParameterTest.java
@@ -28,20 +28,15 @@ import com.gargoylesoftware.htmlunit.WebClientOptions;
 import com.gargoylesoftware.htmlunit.WebRequest;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.util.NameValuePair;
-import hudson.Launcher;
+import hudson.cli.CLICommandInvoker;
 import hudson.model.FreeStyleProject;
 import hudson.model.ParametersDefinitionProperty;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.net.URL;
 import java.util.Arrays;
 
-import hudson.model.StreamBuildListener;
-import org.apache.commons.io.FileUtils;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
@@ -55,9 +50,6 @@ import static org.junit.Assert.*;
 public class BuildSelectorParameterTest {
     @Rule
     public final JenkinsRule rule = new JenkinsRule();
-
-    @Rule
-    public TemporaryFolder tmp = new TemporaryFolder();
 
     /**
      * Verify BuildSelectorParameter works via HTML form, http POST and CLI.
@@ -99,26 +91,10 @@ public class BuildSelectorParameterTest {
         job.getBuildersList().replace(ceb = new CaptureEnvironmentBuilder());
 
         // Run via CLI
-        final File home = tmp.newFolder();
-        final File jar = tmp.newFile("jenkins-cli.jar");
-        FileUtils.copyURLToFile(rule.jenkins.getJnlpJars("jenkins-cli.jar").getURL(), jar);
-
-        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();) {
-            int ret = new Launcher.LocalLauncher(StreamBuildListener.fromStderr())
-                    .launch()
-                    .cmds("java",
-                            "-Duser.home=" + home,
-                            "-jar", jar.getAbsolutePath(),
-                            "-s", rule.getURL().toString(),
-                            "build", job.getFullName(),
-                            "-p", "SELECTOR=<SavedBuildSelector/>")
-                    .stdout(baos)
-                    .stderr(baos)
-                    .join();
-            assertEquals(0, ret);
-            rule.waitUntilNoActivity();
-            assertEquals("<SavedBuildSelector/>", ceb.getEnvVars().get("SELECTOR"));
-        }
+        assertThat(new CLICommandInvoker(rule, "build").invokeWithArgs(job.getFullName(), "-p", "SELECTOR=<SavedBuildSelector/>"),
+                CLICommandInvoker.Matcher.succeeded());
+        rule.waitUntilNoActivity();
+        assertEquals("<SavedBuildSelector/>", ceb.getEnvVars().get("SELECTOR"));
     }
     
     @Test


### PR DESCRIPTION
Executing PCT for _copyartifact-plugin_ against newest versions of jenkins core fail because one test is instantiating CLI using a deprecated constructor that has been removed.
After the execution, `BuildSelectorParameterTest.testParameter` fails with the following trace:
```
java.lang.NoSuchMethodError: hudson.cli.CLI.<init>(Ljava/net/URL;)V
	at hudson.plugins.copyartifact.BuildSelectorParameterTest.testParameter(BuildSelectorParameterTest.java:93)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:548)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:298)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:292)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:748)
```
In `jenkins-1.21.1`, baseline for this plugin, the CLI class had a deprecated constructor used only for testing purposes: https://github.com/jenkinsci/jenkins/blob/8a653f84283b1729d0ecd25138d472de83af1b6d/cli/src/main/java/hudson/cli/CLI.java#L95-L102
Since `jenkins-2.165` this constructor does not exist anymore, so this PR intends to update the test so it is valid with older and newer versions of the core

@ikedam @wolfs 
@alecharp @MRamonLeon @varyvol @rsandell 