### PR TITLE
Correct PCT failures after recent security release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>cloudbees-folder</artifactId>
-        <version>5.16</version>
+        <version>6.1.0</version>
         <optional>true</optional>
       </dependency>
       <dependency>
@@ -94,13 +94,25 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>matrix-auth</artifactId>
-        <version>1.2</version>
+        <version>2.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-support</artifactId>
         <version>3.0</version>
+        <scope>test</scope>
+      </dependency>
+      <!-- 
+        To fix an issue in PCT with scm-api, this plugin is included by workflow-support
+        Otherwise LegacyJobConfigMigrationMonitorMigrationTest refuses to compile due to lack of
+        jenkins/scm/impl/mock/AbstractSampleDVCSRepoRule
+       -->
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>scm-api</artifactId>
+        <version>2.2.6</version>
+        <classifier>tests</classifier>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -132,7 +144,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-durable-task-step</artifactId>
-        <version>2.13</version>
+        <version>2.18</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -234,7 +246,7 @@
           <!-- required by folders plugin -->
           <groupId>org.jenkins-ci.plugins</groupId>
           <artifactId>credentials</artifactId>
-          <version>2.1.8</version>
+          <version>2.1.11</version>
         </dependency>
         <dependency>
           <!-- required by jsch plugin, required by maven-plugin -->

--- a/src/test/java/hudson/plugins/copyartifact/CopyArtifactPermissionPropertyTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/CopyArtifactPermissionPropertyTest.java
@@ -30,6 +30,7 @@ import hudson.matrix.Combination;
 import hudson.matrix.MatrixConfiguration;
 import hudson.matrix.MatrixProject;
 import hudson.matrix.TextAxis;
+import hudson.model.Computer;
 import hudson.model.FreeStyleProject;
 import hudson.model.Item;
 import hudson.model.JobProperty;
@@ -333,6 +334,7 @@ public class CopyArtifactPermissionPropertyTest {
 
         j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
         MockAuthorizationStrategy authStrategy = new MockAuthorizationStrategy();
+        authStrategy.grant(Computer.BUILD).onRoot().toEveryone();
         authStrategy.grant(Item.READ).onItems(upstream).to("alice");
         j.jenkins.setAuthorizationStrategy(authStrategy);
 

--- a/src/test/java/hudson/plugins/copyartifact/monitor/LegacyMonitorDataTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/monitor/LegacyMonitorDataTest.java
@@ -37,6 +37,8 @@ import hudson.security.Permission;
 import hudson.security.ProjectMatrixAuthorizationStrategy;
 import jenkins.model.Jenkins;
 import org.acegisecurity.AccessDeniedException;
+import org.jenkinsci.plugins.matrixauth.inheritance.InheritanceStrategy;
+import org.jenkinsci.plugins.matrixauth.inheritance.NonInheritingStrategy;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -275,9 +277,9 @@ public class LegacyMonitorDataTest {
                     put(Item.READ, new HashSet<>(Arrays.asList("manager")));
                 }}
         ) {
-            @Override
-            public boolean isBlocksInheritance() {
-                return true;
+            @Override 
+            public InheritanceStrategy getInheritanceStrategy() {
+                return new NonInheritingStrategy();
             }
         });
         


### PR DESCRIPTION
The failures were:

<details>

<summary>CopyArtifactPermissionPropertyTest: testNotWorkWithQueueItemAuthenticator
</summary>

```
[ERROR] testNotWorkWithQueueItemAuthenticator(hudson.plugins.copyartifact.CopyArtifactPermissionPropertyTest)  Time elapsed: 180.051 s  <<< ERROR!
org.junit.runners.model.TestTimedOutException: test timed out after 180 seconds
        at java.lang.Object.wait(Native Method)
        at java.lang.Object.wait(Object.java:502)
        at hudson.remoting.AsyncFutureImpl.get(AsyncFutureImpl.java:75)
        at org.jvnet.hudson.test.JenkinsRule.assertBuildStatus(JenkinsRule.java:1253)
        at hudson.plugins.copyartifact.CopyArtifactPermissionPropertyTest.testNotWorkWithQueueItemAuthenticator(CopyArtifactPermissionPropertyTest.java:348)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
        at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
        at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
        at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:556)
        at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:298)
        at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:292)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.lang.Thread.run(Thread.java:748)
```

</details>

<details>

<summary>LegacyJobConfigMigrationMonitorMigrationTest compilation issue</summary>

```
[ERROR] initializationError(hudson.plugins.copyartifact.monitor.LegacyJobConfigMigrationMonitorMigrationTest)  Time elapsed: 0.001 s  <<< ERROR!
java.lang.NoClassDefFoundError: jenkins/scm/impl/mock/AbstractSampleDVCSRepoRule
        at java.lang.ClassLoader.defineClass1(Native Method)
        at java.lang.ClassLoader.defineClass(ClassLoader.java:763)
        at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
        at java.net.URLClassLoader.defineClass(URLClassLoader.java:467)
        at java.net.URLClassLoader.access$100(URLClassLoader.java:73)
        at java.net.URLClassLoader$1.run(URLClassLoader.java:368)
        at java.net.URLClassLoader$1.run(URLClassLoader.java:362)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.net.URLClassLoader.findClass(URLClassLoader.java:361)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:335)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
        at java.lang.Class.getDeclaredFields0(Native Method)
        at java.lang.Class.privateGetDeclaredFields(Class.java:2583)
        at java.lang.Class.getDeclaredFields(Class.java:1916)
        at org.junit.runners.model.TestClass.getSortedDeclaredFields(TestClass.java:77)
        at org.junit.runners.model.TestClass.scanAnnotatedMembers(TestClass.java:70)
        at org.junit.runners.model.TestClass.<init>(TestClass.java:57)
        at org.junit.runners.ParentRunner.createTestClass(ParentRunner.java:88)
        at org.junit.runners.ParentRunner.<init>(ParentRunner.java:83)
        at org.junit.runners.BlockJUnit4ClassRunner.<init>(BlockJUnit4ClassRunner.java:65)
        at org.junit.internal.builders.JUnit4Builder.runnerForClass(JUnit4Builder.java:10)
        at org.junit.runners.model.RunnerBuilder.safeRunnerForClass(RunnerBuilder.java:59)
        at org.junit.internal.builders.AllDefaultPossibilitiesBuilder.runnerForClass(AllDefaultPossibilitiesBuilder.java:26)
        at org.junit.runners.model.RunnerBuilder.safeRunnerForClass(RunnerBuilder.java:59)
        at org.junit.internal.requests.ClassRequest.getRunner(ClassRequest.java:33)
        at org.junit.internal.requests.FilterRequest.getRunner(FilterRequest.java:36)
        at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:362)
        at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:290)
        at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:238)
        at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:159)
        at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
        at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
        at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
        at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)
Caused by: java.lang.ClassNotFoundException: jenkins.scm.impl.mock.AbstractSampleDVCSRepoRule
        at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:335)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
        ... 35 more
```

</details>

<details>

<summary>LegacyMonitorDataTest: buildForCurrentUser_noAccessAndNonExistent</summary>


```
[ERROR] buildForCurrentUser_noAccessAndNonExistent(hudson.plugins.copyartifact.monitor.LegacyMonitorDataTest)  Time elapsed: 2.987 s  <<< FAILURE!
java.lang.AssertionError:
Expected: is <false>
     but: was <true>
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
        at org.junit.Assert.assertThat(Assert.java:956)
        at org.junit.Assert.assertThat(Assert.java:923)
        at hudson.plugins.copyartifact.monitor.LegacyMonitorDataTest.buildForCurrentUser_noAccessAndNonExistent(LegacyMonitorDataTest.java:306)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
        at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:556)
        at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:298)
        at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:292)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.lang.Thread.run(Thread.java:748)
```


</details>

