### PR TITLE
[JENKINS-62409] Use plugin pom 4.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@
 def recentLts = '2.222.4'
 
 buildPlugin(configurations: [
-  [ platform: 'linux', jdk: '8', jenkins: null ],
-  [ platform: 'windows', jdk: '8', jenkins: recentLts, javaLevel: '8' ],
-  [ platform: 'linux', jdk: '11', jenkins: recentLts, javaLevel: '8' ],
+  [ platform: 'linux', jdk: '8' ],
+  [ platform: 'windows', jdk: '8', jenkins: recentLts ],
+  [ platform: 'linux', jdk: '11', jenkins: recentLts ],
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,11 @@
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+// Specify configurations explicitly to test against newer LTS.
+// See also https://github.com/jenkins-infra/pipeline-library/pull/145
+
+// This should be updated manually.
+def recentLts = '2.222.4'
+
+buildPlugin(configurations: [
+  [ platform: 'linux', jdk: '8', jenkins: null ],
+  [ platform: 'windows', jdk: '8', jenkins: recentLts, javaLevel: '8' ],
+  [ platform: 'linux', jdk: '11', jenkins: recentLts, javaLevel: '8' ],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.43</version>
+        <version>4.2</version>
         <relativePath />
     </parent>
 
@@ -26,14 +26,8 @@
     <properties>
         <revision>1.45</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.121.1</jenkins.version>
+        <jenkins.version>2.164.1</jenkins.version>
         <java.level>8</java.level>
-        <workflow-api-plugin.version>2.30</workflow-api-plugin.version>
-        <useBeta>true</useBeta>
-        <workflow-cps-plugin.version>2.32</workflow-cps-plugin.version>
-        <git-plugin.version>3.0.5</git-plugin.version>
-        <workflow-scm-step.version>2.4</workflow-scm-step.version>
-        <workflow-multibranch.version>2.10</workflow-multibranch.version>
     </properties>
 
     <build>
@@ -53,48 +47,34 @@
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>maven-plugin</artifactId>
-        <version>3.1.2</version>
         <optional>true</optional>
-        <exclusions>
-            <exclusion>
-                <!-- to avoid RequireUpperBoundDeps with jenkins-test-harness -->
-                <groupId>commons-net</groupId>
-                <artifactId>commons-net</artifactId>
-            </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
           <groupId>org.jenkins-ci.plugins</groupId>
           <artifactId>structs</artifactId>
-          <version>1.14</version>
       </dependency>
       <dependency>
           <groupId>org.jenkins-ci.plugins</groupId>
           <artifactId>apache-httpcomponents-client-4-api</artifactId>
-          <version>4.5.5-3.0</version>
       </dependency>
       <!-- Used for UI test -->
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>jenkins-test-harness-tools</artifactId>
-        <version>2.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>cloudbees-folder</artifactId>
-        <version>6.1.0</version>
         <optional>true</optional>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>matrix-project</artifactId>
-        <version>1.7.1</version>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-support</artifactId>
-        <version>3.0</version>
         <scope>test</scope>
       </dependency>
       <!-- 
@@ -112,144 +92,99 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-job</artifactId>
-        <version>2.11.2</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-basic-steps</artifactId>
-        <version>2.6</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-cps</artifactId>
-        <version>${workflow-cps-plugin.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <!-- for SnippetizerTester -->
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-cps</artifactId>
-        <version>${workflow-cps-plugin.version}</version>
         <classifier>tests</classifier>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-durable-task-step</artifactId>
-        <version>2.18</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-step-api</artifactId>
-        <version>2.13</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-api</artifactId>
-        <version>${workflow-api-plugin.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>pipeline-build-step</artifactId>
-        <version>2.5.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>compress-artifacts</artifactId>
-        <version>1.10</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <!-- for DirectArtifactManagerFactory -->
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-api</artifactId>
-        <version>${workflow-api-plugin.version}</version>
         <classifier>tests</classifier>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>branch-api</artifactId>
-        <version>2.0.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-multibranch</artifactId>
-        <version>${workflow-multibranch.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <!-- for WorkflowMultiBranchProjectTest -->
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-multibranch</artifactId>
-        <version>${workflow-multibranch.version}</version>
         <scope>test</scope>
         <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>git</artifactId>
-        <version>${git-plugin.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <!-- for GitSampleRepoRule -->
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>git</artifactId>
-        <version>${git-plugin.version}</version>
         <classifier>tests</classifier>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-scm-step</artifactId>
-        <version>${workflow-scm-step.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <!-- for dependency of GitSampleRepoRule -->
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-scm-step</artifactId>
-        <version>${workflow-scm-step.version}</version>
         <classifier>tests</classifier>
         <scope>test</scope>
       </dependency>
     </dependencies>
-    <dependencyManagement>
-      <!-- To resolve RequireUpperBoundDeps errors -->
-      <dependencies>
-        <dependency>
-          <groupId>org.jenkins-ci.plugins</groupId>
-          <artifactId>mailer</artifactId>
-          <version>1.18</version>
-        </dependency>
-        <dependency>
-          <groupId>org.jenkins-ci.plugins</groupId>
-          <artifactId>script-security</artifactId>
-          <version>1.39</version>
-        </dependency>
-        <!--to meet plugin dependencies-->
-        <dependency>
-          <!-- required by folders plugin -->
-          <groupId>org.jenkins-ci.plugins</groupId>
-          <artifactId>credentials</artifactId>
-          <version>2.1.11</version>
-        </dependency>
-        <dependency>
-          <!-- required by jsch plugin, required by maven-plugin -->
-          <groupId>org.jenkins-ci.plugins</groupId>
-          <artifactId>ssh-credentials</artifactId>
-          <version>1.12</version>
-        </dependency>
-      </dependencies>
-    </dependencyManagement>
     <reporting>
       <plugins>
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -29,10 +29,6 @@
         <jenkins.version>2.164.3</jenkins.version>
         <java.level>8</java.level>
         <useBeta>true</useBeta>
-        <maven-plugin.version>3.1.2</maven-plugin.version>
-        <!-- versions for test dependencies -->
-        <compress-artifacts.version>1.10</compress-artifacts.version>
-        <jenkins-test-harness-tools.version>2.0</jenkins-test-harness-tools.version>
         <workflow-multibranch.version>2.10</workflow-multibranch.version>
     </properties>
 
@@ -53,7 +49,7 @@
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>maven-plugin</artifactId>
-        <version>${maven-plugin.version}</version>
+        <version>3.1.2</version>
         <optional>true</optional>
         <exclusions>
             <exclusion>
@@ -75,7 +71,7 @@
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>jenkins-test-harness-tools</artifactId>
-        <version>${jenkins-test-harness-tools.version}</version>
+        <version>2.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -89,22 +85,12 @@
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
-        <artifactId>workflow-support</artifactId>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-job</artifactId>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-basic-steps</artifactId>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins.workflow</groupId>
-        <artifactId>workflow-cps</artifactId>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -115,21 +101,6 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.jenkins-ci.plugins.workflow</groupId>
-        <artifactId>workflow-durable-task-step</artifactId>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins.workflow</groupId>
-        <artifactId>workflow-step-api</artifactId>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins.workflow</groupId>
-        <artifactId>workflow-api</artifactId>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>pipeline-build-step</artifactId>
         <scope>test</scope>
@@ -137,7 +108,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>compress-artifacts</artifactId>
-        <version>${compress-artifacts.version}</version>
+        <version>1.10</version>
         <scope>test</scope>
         <exclusions>
           <exclusion>
@@ -152,11 +123,6 @@
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-api</artifactId>
         <classifier>tests</classifier>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>branch-api</artifactId>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -183,11 +149,6 @@
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>git</artifactId>
         <classifier>tests</classifier>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins.workflow</groupId>
-        <artifactId>workflow-scm-step</artifactId>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.164.1</jenkins.version>
         <java.level>8</java.level>
+        <workflow-multibranch.version>2.10</workflow-multibranch.version>
     </properties>
 
     <build>
@@ -47,6 +48,7 @@
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>maven-plugin</artifactId>
+        <version>3.1.2</version>
         <optional>true</optional>
       </dependency>
       <dependency>
@@ -61,6 +63,7 @@
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>jenkins-test-harness-tools</artifactId>
+        <version>2.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -134,6 +137,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>compress-artifacts</artifactId>
+        <version>1.10</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -151,12 +155,14 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-multibranch</artifactId>
+        <version>${workflow-multibranch.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <!-- for WorkflowMultiBranchProjectTest -->
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-multibranch</artifactId>
+        <version>${workflow-multibranch.version}</version>
         <scope>test</scope>
         <classifier>tests</classifier>
       </dependency>
@@ -181,10 +187,23 @@
         <!-- for dependency of GitSampleRepoRule -->
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-scm-step</artifactId>
+        <!-- Not defined in bom for classifier=tests -->
+        <version>2.4</version>
         <classifier>tests</classifier>
         <scope>test</scope>
       </dependency>
     </dependencies>
+    <dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>io.jenkins.tools.bom</groupId>
+          <artifactId>bom-2.164.x</artifactId>
+          <version>9</version>
+          <scope>import</scope>
+          <type>pom</type>
+        </dependency>
+      </dependencies>
+    </dependencyManagement>
     <reporting>
       <plugins>
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,13 @@
     <properties>
         <revision>1.45</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.164.1</jenkins.version>
+        <jenkins.version>2.164.3</jenkins.version>
         <java.level>8</java.level>
+        <useBeta>true</useBeta>
+        <maven-plugin.version>3.1.2</maven-plugin.version>
+        <!-- versions for test dependencies -->
+        <compress-artifacts.version>1.10</compress-artifacts.version>
+        <jenkins-test-harness-tools.version>2.0</jenkins-test-harness-tools.version>
         <workflow-multibranch.version>2.10</workflow-multibranch.version>
     </properties>
 
@@ -48,8 +53,15 @@
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>maven-plugin</artifactId>
-        <version>3.1.2</version>
+        <version>${maven-plugin.version}</version>
         <optional>true</optional>
+        <exclusions>
+            <exclusion>
+                <!-- to avoid RequireUpperBoundDeps with jenkins-test-harness -->
+                <groupId>commons-net</groupId>
+                <artifactId>commons-net</artifactId>
+            </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
           <groupId>org.jenkins-ci.plugins</groupId>
@@ -63,7 +75,7 @@
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>jenkins-test-harness-tools</artifactId>
-        <version>2.0</version>
+        <version>${jenkins-test-harness-tools.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -78,18 +90,6 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-support</artifactId>
-        <scope>test</scope>
-      </dependency>
-      <!-- 
-        To fix an issue in PCT with scm-api, this plugin is included by workflow-support
-        Otherwise LegacyJobConfigMigrationMonitorMigrationTest refuses to compile due to lack of
-        jenkins/scm/impl/mock/AbstractSampleDVCSRepoRule
-       -->
-      <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>scm-api</artifactId>
-        <version>2.2.6</version>
-        <classifier>tests</classifier>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -137,8 +137,15 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>compress-artifacts</artifactId>
-        <version>1.10</version>
+        <version>${compress-artifacts.version}</version>
         <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <!-- to avoid RequireUpperBoundDeps with git plugin -->
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <!-- for DirectArtifactManagerFactory -->
@@ -185,10 +192,8 @@
       </dependency>
       <dependency>
         <!-- for dependency of GitSampleRepoRule -->
-        <groupId>org.jenkins-ci.plugins.workflow</groupId>
-        <artifactId>workflow-scm-step</artifactId>
-        <!-- Not defined in bom for classifier=tests -->
-        <version>2.4</version>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>scm-api</artifactId>
         <classifier>tests</classifier>
         <scope>test</scope>
       </dependency>
@@ -198,7 +203,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
           <artifactId>bom-2.164.x</artifactId>
-          <version>9</version>
+          <version>10</version>
           <scope>import</scope>
           <type>pom</type>
         </dependency>

--- a/src/test/java/hudson/plugins/copyartifact/ParameterizedBuildSelectorTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/ParameterizedBuildSelectorTest.java
@@ -27,6 +27,7 @@ package hudson.plugins.copyartifact;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
+import java.io.InputStream;
 
 import jenkins.util.VirtualFile;
 import hudson.model.FreeStyleBuild;
@@ -39,8 +40,8 @@ import hudson.model.StringParameterValue;
 import hudson.plugins.copyartifact.testutils.CopyArtifactUtil;
 import hudson.plugins.copyartifact.testutils.FileWriteBuilder;
 import hudson.tasks.ArtifactArchiver;
-import hudson.util.IOUtils;
 
+import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -131,7 +132,9 @@ public class ParameterizedBuildSelectorTest {
         ));
         
         VirtualFile vf = b.getArtifactManager().root().child("artifact.txt");
-        assertEquals("foobar", IOUtils.toString(vf.open()));
+        try(InputStream in = vf.open()) {
+            assertEquals("foobar", IOUtils.toString(in, "UTF-8"));
+        }
     }
     
     /**
@@ -267,7 +270,9 @@ public class ParameterizedBuildSelectorTest {
         ));
         
         VirtualFile vf = b.getArtifactManager().root().child("artifact.txt");
-        assertEquals("foobar", IOUtils.toString(vf.open()));
+        try(InputStream in = vf.open()) {
+            assertEquals("foobar", IOUtils.toString(in, "UTF-8"));
+        }
     }
     
     


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-62409

* Use plugin pom 4.0: https://github.com/jenkinsci/plugin-pom/tree/plugin-4.2
* Use jenkins bom: https://github.com/jenkinsci/bom/tree/bom-10
* Specify CI configurations explicitly instead of `recommendedConfigurations`
    * https://github.com/jenkins-infra/pipeline-library/pull/145
    * I actually don't think that's a good idea to specify configurations explicitly as we have to update Jenkinsfile manually. But Jenkins-2.164.1, the current target with `recommendedConfigurations` is old and I believe the root cause of #119 is the issue of `recommendedConfigurations`. 


I already removed the dependency to matrix-auth in #122 .
