### PR TITLE
[JENKINS-62267] Add test case for JENKINS-62267

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,27 @@
         <classifier>tests</classifier>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>org.datadog.jenkins.plugins</groupId>
+        <artifactId>datadog</artifactId>
+        <version>1.1.2</version>
+        <scope>test</scope>
+        <exclusions>
+          <!-- to avoid RequireUpperBoundDeps with Jenkins core -->
+          <exclusion>
+            <groupId>com.github.jnr</groupId>
+            <artifactId>jnr-constants</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.github.jnr</groupId>
+            <artifactId>jnr-ffi</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.github.jnr</groupId>
+            <artifactId>jnr-posix</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
     </dependencies>
     <dependencyManagement>
       <dependencies>

--- a/src/test/java/hudson/plugins/copyartifact/CopyArtifactConfigurationTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/CopyArtifactConfigurationTest.java
@@ -23,15 +23,18 @@
  */
 package hudson.plugins.copyartifact;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 import org.hamcrest.Matchers;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import org.jvnet.hudson.test.recipes.LocalData;
 
 /**
  * Tests for {@link CopyArtifactConfiguration}
@@ -88,5 +91,13 @@ public class CopyArtifactConfigurationTest {
         config.setToFirstLoad();
         config.load();
         assertThat(config.getMode(), Matchers.is(CopyArtifactCompatibilityMode.MIGRATION));
+    }
+
+    @Ignore("Currently fails with circular dependency error")
+    @Issue("JENKINS-62267")
+    @LocalData
+    @Test
+    public void circularDependencyTest() throws Exception {
+        assertNotNull(CopyArtifactConfiguration.get());
     }
 }

--- a/src/test/resources/hudson/plugins/copyartifact/CopyArtifactConfigurationTest/circularDependencyTest/org.datadog.jenkins.plugins.datadog.DatadogGlobalConfiguration.xml
+++ b/src/test/resources/hudson/plugins/copyartifact/CopyArtifactConfigurationTest/circularDependencyTest/org.datadog.jenkins.plugins.datadog.DatadogGlobalConfiguration.xml
@@ -1,0 +1,11 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<org.datadog.jenkins.plugins.datadog.DatadogGlobalConfiguration>
+  <reportWith>DSD</reportWith>
+  <targetApiURL>https://api.datadoghq.com/api/</targetApiURL>
+  <targetLogIntakeURL>https://http-intake.logs.datadoghq.com/v1/input/</targetLogIntakeURL>
+  <targetHost>localhost</targetHost>
+  <targetPort>8125</targetPort>
+  <emitSecurityEvents>true</emitSecurityEvents>
+  <emitSystemEvents>true</emitSystemEvents>
+  <collectBuildLogs>false</collectBuildLogs>
+</org.datadog.jenkins.plugins.datadog.DatadogGlobalConfiguration>


### PR DESCRIPTION
See [JENKINS-62267](https://issues.jenkins-ci.org/browse/JENKINS-62267). Adds a reproducible test case for the issue, marked with `@Ignore` because the test currently fails. When the issue is resolved, the `@Ignore` annotation can be removed. I suggest looking at the fixes for [JENKINS-60393](https://issues.jenkins-ci.org/browse/JENKINS-60393) and [JENKINS-39169](https://issues.jenkins-ci.org/browse/JENKINS-39169) for inspiration as to how to fix this error.