### PR TITLE
[FIXED JENKINS-63185] Display the description of BuildSelectorParameter

### DIFF
--- a/src/main/resources/hudson/plugins/copyartifact/BuildSelectorParameter/index.jelly
+++ b/src/main/resources/hudson/plugins/copyartifact/BuildSelectorParameter/index.jelly
@@ -26,12 +26,13 @@ THE SOFTWARE.
   <j:scope>
   <j:set var="descriptor" value="${it.descriptor}" /> <!-- this enables displaying the help file. -->
   <f:dropdownDescriptorSelector field="parameter"
-      title="${it.name}" description="${it.description}"
+      title="${it.name}"
       default="${it.defaultSelector}"
       descriptors="${it.descriptor.availableBuildSelectorList}">
     <j:if test="${dropdownListMode=='generateEntries'}">
       <tr><td><input type="hidden" name="name" value="${it.name}"/></td></tr>
     </j:if>
   </f:dropdownDescriptorSelector>
+  <f:description>${it.description}</f:description>
   </j:scope>
 </j:jelly>


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-63185

* Configure the description of BuildSelectorParameter
![Screenshot_2020-07-25 freestyle Config  Jenkins](https://user-images.githubusercontent.com/3115961/88447976-e2366d00-ce73-11ea-81b7-6c4e85d783f7.png)
* The description is not shown on Build with parameter page:
![Screenshot_2020-07-25 Jenkins](https://user-images.githubusercontent.com/3115961/88447982-ef535c00-ce73-11ea-858c-d7d12db9918a.png)
* This change fixes the issue and displays the description:
![Screenshot_2020-07-25 Jenkins(1)](https://user-images.githubusercontent.com/3115961/88447992-02fec280-ce74-11ea-9d5a-503fa4ec1db8.png)
* Limitation: the description is displayed below the help area though Jenkins standard layouts displays description above the help area. It's for f:dropdownDescriptorSelector doesn't support description.
![Screenshot_2020-07-25 Jenkins(2)](https://user-images.githubusercontent.com/3115961/88448012-393c4200-ce74-11ea-9f44-fed7ca43b4c9.png)


