### PR TITLE
[JENKINS-65988] Remove usages of Guava

### DIFF
--- a/src/main/java/hudson/plugins/copyartifact/BuildSelectorParameter.java
+++ b/src/main/java/hudson/plugins/copyartifact/BuildSelectorParameter.java
@@ -26,6 +26,7 @@ package hudson.plugins.copyartifact;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import com.thoughtworks.xstream.XStreamException;
 import jenkins.model.Jenkins;
@@ -43,10 +44,6 @@ import net.sf.json.JSONObject;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
-
-import com.google.common.base.Predicate;
-import com.google.common.collect.Collections2;
-import com.google.common.collect.Lists;
 
 /**
  * @author Alan Harder
@@ -150,14 +147,9 @@ public class BuildSelectorParameter extends SimpleParameterDefinition {
             if (jenkins == null) {
                 return Collections.emptyList();
             }
-            return Lists.newArrayList(Collections2.filter(
-                    jenkins.getDescriptorList(BuildSelector.class),
-                    new Predicate<Descriptor<BuildSelector>>() {
-                        public boolean apply(Descriptor<BuildSelector> input) {
-                            return !"ParameterizedBuildSelector".equals(input.clazz.getSimpleName());
-                        };
-                    }
-            ));
+            return jenkins.getDescriptorList(BuildSelector.class).stream()
+                    .filter(input -> !"ParameterizedBuildSelector".equals(input.clazz.getSimpleName()))
+                    .collect(Collectors.toList());
         }
         
         @Override

--- a/src/main/java/hudson/plugins/copyartifact/CopyArtifactPermissionProperty.java
+++ b/src/main/java/hudson/plugins/copyartifact/CopyArtifactPermissionProperty.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import javax.annotation.CheckForNull;
 
@@ -41,9 +42,6 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
-
-import com.google.common.base.Function;
-import com.google.common.collect.Lists;
 
 import hudson.Extension;
 import hudson.model.AutoCompletionCandidates;
@@ -127,11 +125,10 @@ public class CopyArtifactPermissionProperty extends JobProperty<Job<?,?>> {
         }
         
         List<String> literals = Arrays.asList(pattern.split("\\*", -1));
-        String regex = StringUtils.join(Lists.transform(literals, new Function<String, String>() {
-            public String apply(String input) {
-                return (input != null)?Pattern.quote(input):"";
-            }
-        }), ".*");
+        String regex =
+                literals.stream()
+                        .map(input -> input != null ? Pattern.quote(input) : "")
+                        .collect(Collectors.joining(".*"));
         return name.matches(regex);
     }
     

--- a/src/main/java/hudson/plugins/copyartifact/monitor/LegacyJobConfigMigrationMonitor.java
+++ b/src/main/java/hudson/plugins/copyartifact/monitor/LegacyJobConfigMigrationMonitor.java
@@ -125,6 +125,7 @@ public class LegacyJobConfigMigrationMonitor extends AdministrativeMonitor imple
     /**
      * @return data holding the list of jobs to warn.
      */
+    @Restricted(NoExternalUse.class)
     /* Visible for testing */ LegacyMonitorData getData() {
         return data;
     }

--- a/src/main/java/hudson/plugins/copyartifact/monitor/LegacyJobConfigMigrationMonitor.java
+++ b/src/main/java/hudson/plugins/copyartifact/monitor/LegacyJobConfigMigrationMonitor.java
@@ -24,7 +24,6 @@
 package hudson.plugins.copyartifact.monitor;
 
 import com.cloudbees.hudson.plugins.folder.computed.ComputedFolder;
-import com.google.common.annotations.VisibleForTesting;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.BulkChange;
@@ -126,7 +125,7 @@ public class LegacyJobConfigMigrationMonitor extends AdministrativeMonitor imple
     /**
      * @return data holding the list of jobs to warn.
      */
-    @VisibleForTesting LegacyMonitorData getData() {
+    /* Visible for testing */ LegacyMonitorData getData() {
         return data;
     }
     
@@ -325,7 +324,7 @@ public class LegacyJobConfigMigrationMonitor extends AdministrativeMonitor imple
         }
     }
 
-    @VisibleForTesting
+    /* Visible for testing */
     @Restricted(NoExternalUse.class)
     boolean applyAutoMigration(@Nonnull String jobFromName, @Nonnull String jobToName) throws IOException {
         Jenkins jenkins = Jenkins.get();

--- a/src/main/java/hudson/plugins/copyartifact/monitor/LegacyMonitorData.java
+++ b/src/main/java/hudson/plugins/copyartifact/monitor/LegacyMonitorData.java
@@ -23,7 +23,6 @@
  */
 package hudson.plugins.copyartifact.monitor;
 
-import com.google.common.annotations.VisibleForTesting;
 import hudson.model.Job;
 import hudson.security.ACL;
 import hudson.security.ACLContext;
@@ -156,7 +155,7 @@ public class LegacyMonitorData {
      * @return map map from the pair of jobs to the possible failure build.
      */
     @Restricted(NoExternalUse.class)
-    @VisibleForTesting @Nonnull Map<JobKey, LegacyBuildStorage> getLegacyJobInfos() {
+    /* Visible for testing */ @Nonnull Map<JobKey, LegacyBuildStorage> getLegacyJobInfos() {
         return new HashMap<>(legacyJobInfos);
     }
     
@@ -166,7 +165,7 @@ public class LegacyMonitorData {
      * @return map map from the job name to all existing pair of jobs.
      */
     @Restricted(NoExternalUse.class)
-    @VisibleForTesting @Nonnull Map<String, List<JobKey>> getFullNameToKey() {
+    /* Visible for testing */ @Nonnull Map<String, List<JobKey>> getFullNameToKey() {
         Map<String, List<JobKey>> result = new HashMap<>();
         
         fullNameToKey.forEach((key, value) -> result.put(key, new ArrayList<>(value)));
@@ -180,7 +179,7 @@ public class LegacyMonitorData {
      * Clear all.
      */
     @Restricted(NoExternalUse.class)
-    @VisibleForTesting void clear() {
+    /* Visible for testing */ void clear() {
         this.fullNameToKey.clear();
         this.legacyJobInfos.clear();
     }
@@ -327,7 +326,7 @@ public class LegacyMonitorData {
      */
     @Restricted(NoExternalUse.class)
     @Nonnull
-    @VisibleForTesting static JobKey buildKey(@Nonnull String jobFrom, @Nonnull String jobTo) {
+    /* Visible for testing */ static JobKey buildKey(@Nonnull String jobFrom, @Nonnull String jobTo) {
         return new JobKey(jobFrom, jobTo);
     }
     

--- a/src/test/java/hudson/plugins/copyartifact/monitor/LegacyJobConfigMigrationMonitorTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/monitor/LegacyJobConfigMigrationMonitorTest.java
@@ -43,6 +43,8 @@ import hudson.plugins.copyartifact.CopyArtifactPermissionProperty;
 import hudson.plugins.copyartifact.testutils.CopyArtifactJenkinsRule;
 import hudson.plugins.copyartifact.testutils.FileWriteBuilder;
 import hudson.tasks.ArtifactArchiver;
+import java.util.Arrays;
+import java.util.HashSet;
 import jenkins.model.Jenkins;
 import jenkins.model.ParameterizedJobMixIn;
 import jenkins.security.QueueItemAuthenticator;
@@ -56,8 +58,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.recipes.LocalData;
-
-import com.google.common.collect.Sets;
 
 import javax.annotation.CheckForNull;
 
@@ -831,7 +831,7 @@ public class LegacyJobConfigMigrationMonitorTest {
         LegacyJobConfigMigrationMonitor monitor = LegacyJobConfigMigrationMonitor.get();
         assertThat(
             monitor.getData().getFullNameToKey().keySet(),
-            Matchers.is(Sets.newHashSet("dest", "src"))
+            Matchers.is(new HashSet<>(Arrays.asList("dest", "src")))
         );
 
         src.addProperty(new CopyArtifactPermissionProperty("dest"));


### PR DESCRIPTION
To avoid any potential binary incompatibilities between Guava 11 and the latest version of Guava in the forthcoming upgrade of Guava from Jenkins core, remove the Guava dependency from this plugin. This plugin doesn't need Guava; all its needs can be satisfied with native Java Platform functionality.