### PR TITLE
Use Maven3 for tests

### DIFF
--- a/src/test/java/hudson/plugins/copyartifact/CopyArtifactTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/CopyArtifactTest.java
@@ -466,7 +466,7 @@ public class CopyArtifactTest {
     }
 
     private MavenModuleSet setupMavenJob() throws Exception {
-        ToolInstallations.configureDefaultMaven();
+        ToolInstallations.configureMaven3();
         MavenModuleSet mp = createMavenProject();
         mp.setGoals("clean package -Dmaven.compiler.source=1.8 -Dmaven.compiler.target=1.8");
         mp.setScm(rule.getExtractResourceScm(tempFolder, getClass().getResource("maven-job")));

--- a/src/test/java/hudson/plugins/copyartifact/TriggeredBuildSelectorTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/TriggeredBuildSelectorTest.java
@@ -924,7 +924,7 @@ public class TriggeredBuildSelectorTest {
     @Issue("JENKINS-14653")
     @Test
     public void testMavenModule() throws Exception {
-        ToolInstallations.configureDefaultMaven();
+        ToolInstallations.configureMaven3();
         MavenModuleSet upstream = createMavenProject();
         FreeStyleProject downstream = j.createFreeStyleProject();
         

--- a/src/test/java/hudson/plugins/copyartifact/monitor/LegacyJobConfigMigrationMonitorMigrationTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/monitor/LegacyJobConfigMigrationMonitorMigrationTest.java
@@ -374,7 +374,7 @@ public class LegacyJobConfigMigrationMonitorMigrationTest {
 
     @Test
     public void migrate_maven_to_pipeline() throws Exception {
-        ToolInstallations.configureDefaultMaven();
+        ToolInstallations.configureMaven3();
         MavenModuleSet src = j.createProject(MavenModuleSet.class);
         src.setScm(j.getExtractResourceScm(tempFolder, getClass().getResource("../maven-job")));
         src.setRunHeadless(true);
@@ -401,7 +401,7 @@ public class LegacyJobConfigMigrationMonitorMigrationTest {
 
     @Test
     public void migrate_mavenmodule_to_pipeline() throws Exception {
-        ToolInstallations.configureDefaultMaven();
+        ToolInstallations.configureMaven3();
         MavenModuleSet src = j.createProject(MavenModuleSet.class);
         src.setScm(j.getExtractResourceScm(tempFolder, getClass().getResource("../maven-job")));
         src.setRunHeadless(true);
@@ -438,7 +438,7 @@ public class LegacyJobConfigMigrationMonitorMigrationTest {
         ));
         j.assertBuildStatusSuccess(src.scheduleBuild2(0));
 
-        ToolInstallations.configureDefaultMaven();
+        ToolInstallations.configureMaven3();
         MavenModuleSet dst = j.createProject(MavenModuleSet.class);
         dst.setScm(j.getExtractResourceScm(tempFolder, getClass().getResource("../maven-job")));
         dst.setRunHeadless(true);


### PR DESCRIPTION
Whilst investigating a different issue the tests that used maven would
reliably fail as my maven `settings.xml` is not compatible with Maven2 (as
it uses some maven 3 features).

Maven2 was end of line in 2014-02-18 so just bump the plugin to use maven3 (still an old version of 3, but better than 2!) in its tests.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
