### PR TITLE
Compatibility with jenkins-2.325 and later (jenkinsci/jenkins#6025)

### DIFF
--- a/src/main/java/hudson/plugins/copyartifact/CopyArtifactConfiguration.java
+++ b/src/main/java/hudson/plugins/copyartifact/CopyArtifactConfiguration.java
@@ -33,6 +33,7 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
+import java.io.IOException;
 import java.util.logging.Logger;
 
 import javax.annotation.CheckForNull;
@@ -127,7 +128,7 @@ public class CopyArtifactConfiguration extends GlobalConfiguration {
      * Set the the first load status. Use only for testing purpose.
      */
     @Restricted(NoExternalUse.class)
-    public void setToFirstLoad() {
+    public void setToFirstLoad() throws IOException {
         getConfigFile().delete();
     }
     


### PR DESCRIPTION
This method is changing in jenkinsci/jenkins#6025 to throw `IOException`, so callers need to be adapted.