### PR TITLE
Adapt icon path removal from core

### DIFF
--- a/src/main/resources/hudson/plugins/copyartifact/monitor/LegacyJobConfigMigrationMonitor/manage.jelly
+++ b/src/main/resources/hudson/plugins/copyartifact/monitor/LegacyJobConfigMigrationMonitor/manage.jelly
@@ -95,7 +95,7 @@ THE SOFTWARE.
                                         <tr>
                                             <td class="first-column">
                                                 <j:if test="${!isValid}">
-                                                    <l:icon style="padding: 0 0 0 4px" class="icon-warning icon-sm" title="${%InvalidWarning.title}" />
+                                                    <l:icon class="icon-warning icon-sm" title="${%InvalidWarning.title}" />
                                                 </j:if>
                                             </td>
                                             <td>

--- a/src/main/resources/hudson/plugins/copyartifact/monitor/LegacyJobConfigMigrationMonitor/manage.jelly
+++ b/src/main/resources/hudson/plugins/copyartifact/monitor/LegacyJobConfigMigrationMonitor/manage.jelly
@@ -95,15 +95,15 @@ THE SOFTWARE.
                                         <tr>
                                             <td class="first-column">
                                                 <j:if test="${!isValid}">
-                                                    <img class="first-column-icon" src="${imagesURL}/16x16/warning.png" title="${%InvalidWarning.title}" />
+                                                    <l:icon style="padding: 0 0 0 4px" class="icon-warning icon-sm" title="${%InvalidWarning.title}" />
                                                 </j:if>
                                             </td>
                                             <td>
                                                 <j:if test="${jobFrom.autoMigratable}">
-                                                    <img src="${imagesURL}/16x16/accept.png" title="${%CanMigrate}" />
+                                                    <l:icon class="icon-accept icon-sm" title="${%CanMigrate}" />
                                                 </j:if>
                                                 <j:if test="${!jobFrom.autoMigratable}">
-                                                    <img src="${imagesURL}/16x16/stop.png" title="${%CanNotMigrate}" />
+                                                    <l:icon class="icon-stop icon-sm" title="${%CanNotMigrate}" />
                                                 </j:if>
                                             </td>
                                             <td>

--- a/src/main/resources/hudson/plugins/copyartifact/monitor/LegacyJobConfigMigrationMonitor/resources.css
+++ b/src/main/resources/hudson/plugins/copyartifact/monitor/LegacyJobConfigMigrationMonitor/resources.css
@@ -27,7 +27,8 @@
 .legacy-copy-artifact table tr td.first-column {
     padding: 0;
 }
-.legacy-copy-artifact table tr td img.first-column-icon {
+.legacy-copy-artifact table tr td.first-column .icon-warning {
+    box-sizing: content-box;
     padding: 0;
     padding-left: 4px;
 }

--- a/src/main/resources/hudson/plugins/copyartifact/monitor/LegacyJobConfigMigrationMonitor/resources.css
+++ b/src/main/resources/hudson/plugins/copyartifact/monitor/LegacyJobConfigMigrationMonitor/resources.css
@@ -28,9 +28,7 @@
     padding: 0;
 }
 .legacy-copy-artifact table tr td.first-column .icon-warning {
-    box-sizing: content-box;
-    padding: 0;
-    padding-left: 4px;
+    margin-left: 4px;
 }
 
 .legacy-copy-artifact table .no-project {


### PR DESCRIPTION
The change proposed prepares the plugin for the icon path removal from core in the upcoming LTS line. This change affects plugins not using the icon API or relying on paths. Plugins using the API properly in the first place are unaffected by this change.

Could you trigger a release after merging this PR please, giving people a chance to update the plugin before updating to the next LTS version @ikedam 
Thanks in advance!