### PR TITLE
Replace HttpStatus import with a constant

### DIFF
--- a/src/test/java/hudson/plugins/copyartifact/testutils/CopyArtifactJenkinsRule.java
+++ b/src/test/java/hudson/plugins/copyartifact/testutils/CopyArtifactJenkinsRule.java
@@ -39,7 +39,6 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.commons.httpclient.HttpStatus;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.junit.rules.TemporaryFolder;
@@ -55,6 +54,8 @@ import hudson.scm.SCM;
  *
  */
 public class CopyArtifactJenkinsRule extends JenkinsRule {
+    private static final int SC_METHOD_NOT_ALLOWED = 405;
+    
     /**
      * Get Web Client that allows 405 Method Not Allowed.
      * This happens when accessing build page of a project with parameters.
@@ -69,7 +70,7 @@ public class CopyArtifactJenkinsRule extends JenkinsRule {
             public void throwFailingHttpStatusCodeExceptionIfNecessary(
                     WebResponse webResponse
             ) {
-                if(webResponse.getStatusCode() == HttpStatus.SC_METHOD_NOT_ALLOWED) {
+                if(webResponse.getStatusCode() == SC_METHOD_NOT_ALLOWED) {
                     // allow 405.
                     return;
                 }
@@ -78,7 +79,7 @@ public class CopyArtifactJenkinsRule extends JenkinsRule {
 
             @Override
             public void printContentIfNecessary(WebResponse webResponse) {
-                if(webResponse.getStatusCode() == HttpStatus.SC_METHOD_NOT_ALLOWED)
+                if(webResponse.getStatusCode() == SC_METHOD_NOT_ALLOWED)
                 {
                     // allow 405.
                     return;


### PR DESCRIPTION
## Replace HttpStatus import in test with a constant

The HttpClient 3.x library has been removed from Jenkins 2.379.  This test depended on that library to provide a definition of HTTP status code 405, "Not allowed".  Replace the reference to that Java class with a constant.

See https://github.com/jenkinsci/bom/pull/1602 for BOM pull request that detected the issue.

I believe we'll need a new release of the copyartifact plugin and then an update to the plugin bill of materials to include that new release of the copyartifact plugin.

Prior to this pull request, the failure is visible with:

```
$ mvn clean -Dtest=InjectedTest -Djenkins.version=2.379 test
```

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

@basil would you be willing to review this pull request?