### PR TITLE
Removing test dep on `compress-artifacts`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,12 +106,6 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>compress-artifacts</artifactId>
-        <version>98.vb_20f3c77ddf7</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <!-- for DirectArtifactManagerFactory -->
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-api</artifactId>

--- a/src/test/java/hudson/plugins/copyartifact/CopyArtifactTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/CopyArtifactTest.java
@@ -94,7 +94,6 @@ import org.acegisecurity.context.SecurityContext;
 import org.acegisecurity.context.SecurityContextHolder;
 import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
 import org.apache.commons.lang.StringUtils;
-import org.jenkinsci.plugins.compress_artifacts.CompressingArtifactManagerFactory;
 import org.jenkinsci.plugins.workflow.DirectArtifactManagerFactory;
 import org.junit.After;
 import org.junit.ClassRule;
@@ -2338,19 +2337,6 @@ public class CopyArtifactTest {
                     ceb.getEnvVars().get("COPYARTIFACT_BUILD_NUMBER_SRC_PROJECT_")
             );
         }
-    }
-
-    @Issue("JENKINS-22637")
-    @Test
-    public void compressArtifacts() throws Exception {
-        ArtifactManagerConfiguration.get().getArtifactManagerFactories().add(new CompressingArtifactManagerFactory());
-        FreeStyleProject other = createArtifactProject();
-        rule.buildAndAssertSuccess(other);
-        FreeStyleProject p = createProject(other.getName(), null, "", "", false, false, false, false);
-        FreeStyleBuild b = rule.buildAndAssertSuccess(p);
-        assertFile(true, "foo.txt", b);
-        assertFile(true, "subdir/subfoo.txt", b);
-        assertFile(true, "deepfoo/a/b/c.log", b);
     }
 
     @Issue("JENKINS-49635")


### PR DESCRIPTION
Problematic for various reasons (not in BOM, uses an obsolete library, pulls in BouncyCastle not through the plugin). Easiest to just remove this test dep as it should add no interesting test coverage beyond what we already get from the `workflow-api:tests` dep. See https://github.com/jenkinsci/bom/pull/1689#issuecomment-1386975882 for context.