### PR TITLE
Require Jenkins 2.361.4 or newer (Java 11)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,8 +2,6 @@
 // See also https://github.com/jenkins-infra/pipeline-library/pull/145
 
 buildPlugin(useContainerAgent: true, configurations: [
-  [ platform: 'linux', jdk: '8' ],
   [ platform: 'linux', jdk: '11' ],
-  [ platform: 'windows', jdk: '11' ],
-  [ platform: 'linux', jdk: '17' ],
+  [ platform: 'windows', jdk: '17' ],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.51</version>
+        <version>4.54</version>
         <relativePath />
     </parent>
 
@@ -28,7 +28,7 @@
         <revision>1.49</revision>
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-        <jenkins.version>2.319.3</jenkins.version>
+        <jenkins.version>2.361.4</jenkins.version>
         <useBeta>true</useBeta>
     </properties>
 
@@ -49,15 +49,8 @@
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>maven-plugin</artifactId>
-        <version>3.16</version>
+        <version>3.19</version>
         <optional>true</optional>
-        <exclusions>
-            <exclusion>
-                <!-- to avoid RequireUpperBoundDeps with jenkins-test-harness -->
-                <groupId>commons-net</groupId>
-                <artifactId>commons-net</artifactId>
-            </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
           <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -159,28 +159,13 @@
       <dependencies>
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
-          <artifactId>bom-2.319.x</artifactId>
-          <version>1654.vcb_69d035fa_20</version>
+          <artifactId>bom-2.361.x</artifactId>
+          <version>1792.v0295db_e7c548</version>
           <scope>import</scope>
           <type>pom</type>
         </dependency>
       </dependencies>
     </dependencyManagement>
-    <reporting>
-      <plugins>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>cobertura-maven-plugin</artifactId>
-          <version>2.7</version>
-          <configuration>
-            <formats>
-              <format>xml</format>
-              <format>html</format>
-            </formats>
-          </configuration>
-        </plugin>
-      </plugins>
-    </reporting>
 
     <scm>
       <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -99,12 +99,6 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>compress-artifacts</artifactId>
-        <version>98.vb_20f3c77ddf7</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <!-- for DirectArtifactManagerFactory -->
         <groupId>org.jenkins-ci.plugins.workflow</groupId>
         <artifactId>workflow-api</artifactId>

--- a/src/test/java/hudson/plugins/copyartifact/CopyArtifactTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/CopyArtifactTest.java
@@ -94,7 +94,6 @@ import org.acegisecurity.context.SecurityContext;
 import org.acegisecurity.context.SecurityContextHolder;
 import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
 import org.apache.commons.lang.StringUtils;
-import org.jenkinsci.plugins.compress_artifacts.CompressingArtifactManagerFactory;
 import org.jenkinsci.plugins.workflow.DirectArtifactManagerFactory;
 import org.junit.After;
 import org.junit.ClassRule;
@@ -2338,19 +2337,6 @@ public class CopyArtifactTest {
                     ceb.getEnvVars().get("COPYARTIFACT_BUILD_NUMBER_SRC_PROJECT_")
             );
         }
-    }
-
-    @Issue("JENKINS-22637")
-    @Test
-    public void compressArtifacts() throws Exception {
-        ArtifactManagerConfiguration.get().getArtifactManagerFactories().add(new CompressingArtifactManagerFactory());
-        FreeStyleProject other = createArtifactProject();
-        rule.buildAndAssertSuccess(other);
-        FreeStyleProject p = createProject(other.getName(), null, "", "", false, false, false, false);
-        FreeStyleBuild b = rule.buildAndAssertSuccess(p);
-        assertFile(true, "foo.txt", b);
-        assertFile(true, "subdir/subfoo.txt", b);
-        assertFile(true, "deepfoo/a/b/c.log", b);
     }
 
     @Issue("JENKINS-49635")


### PR DESCRIPTION
## Require Jenkins 2.361.4 or newer (Java 11)

- Removing test dep on `compress-artifacts`
- Remove cobertura reporting, jacoco provided by parent
- Require Jenkins 2.361.4 or newer
- Do not test Java 8 in CI

Includes #163 and supersedes #159 and #162

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
