### PR TITLE
Use optional maven integration 3.16, not 3.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>maven-plugin</artifactId>
-        <version>3.19</version>
+        <version>3.16</version>
         <optional>true</optional>
       </dependency>
       <dependency>


### PR DESCRIPTION
The plugin compatbility tester reports that the upgrade of the maven
integration plugin dependency from 3.16 to 3.19 is a problem.

https://github.com/jenkinsci/bom/pull/1703/checks is the archive of the
failing checks.

There was no strong reason to upgrade to the newer integration plugin
version in the previous release.  I upgraded because 3.19 is reasonably
recent (released 8 months ago) and after the upgrade to Jenkins 2.321+
that was done in 3.17.

Restoring the minimum dependency to 3.16 does not prevent users from
installing or using more recent releases of the maven integration plugin.
