### PR TITLE
Remove empty translation properties

### DIFF
--- a/src/main/resources/hudson/plugins/copyartifact/CopyArtifact/config_de.properties
+++ b/src/main/resources/hudson/plugins/copyartifact/CopyArtifact/config_de.properties
@@ -5,5 +5,3 @@ Target\ directory=Zielverzeichnis
 Flatten\ directories=Verzeichnisse reduzieren
 Fingerprint\ Artifacts=Fingerabdr\u00fccke von Artefakten erstellen
 Optional=Optional
-Fingerprint\ Artifacts=
-Include\ Build\ Number=

--- a/src/main/resources/hudson/plugins/copyartifact/CopyArtifact/config_ja.properties
+++ b/src/main/resources/hudson/plugins/copyartifact/CopyArtifact/config_ja.properties
@@ -5,5 +5,3 @@ Artifacts\ not\ to\ copy=\u30b3\u30d4\u30fc\u3057\u306a\u3044\u6210\u679c\u7269
 Target\ directory=\u30B3\u30D4\u30FC\u5148\u30C7\u30A3\u30EC\u30AF\u30C8\u30EA
 Flatten\ directories=\u30C7\u30A3\u30EC\u30AF\u30C8\u30EA\u69CB\u9020\u3092\u7121\u8996
 Optional=\u30AA\u30D7\u30B7\u30E7\u30F3
-Fingerprint\ Artifacts=
-Include\ Build\ Number=


### PR DESCRIPTION
## Remove empty translation properties

https://github.com/jenkinsci/copyartifact-plugin/pull/169 added empty translation strings.  They will cause the two items to be shown as empty strings in the local language versions (German and Japanese).  Better to remove the empty translation properties so that the English will be displayed.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
