### PR TITLE
Revert "Bump maven-plugin from 3.16 to 3.21"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,9 @@
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>maven-plugin</artifactId>
+        <!-- Intentionally kept at 3.16 to not disrupt Jenkins plugin bill of materials -->
+        <!-- https://github.com/jenkinsci/bom/pull/1978#issuecomment-1516220549 -->
+        <!-- TODO: Before upgrading this version, must check that plugin bill of materials is unharmed -->
         <version>3.16</version>
         <optional>true</optional>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>maven-plugin</artifactId>
-        <version>3.21</version>
+        <version>3.16</version>
         <optional>true</optional>
       </dependency>
       <dependency>


### PR DESCRIPTION
Reverts jenkinsci/copyartifact-plugin#174

See discussion in https://github.com/jenkinsci/bom/pull/1978 for the detailed motivation for this change.

It is generally good to upgrade dependencies, but in this case, the upgraded dependency complicates the Jenkins plugin bill of materials.  Rather than complicate something that is widely used in the Jenkins project, let's intentionally retain this optional dependency at its older version.

This pull request is ready for review because the incremental build of the pull request evaluated successfully in the Jenkins plugin bill of materials.  @allancth, once this is merged, it will generate a new release.