### PR TITLE
Revert maven plugin upgrade

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    ignore:
+      # maven plugin updates break plugin bill of materials
+      # do not offer minor version updates
+      - dependency-name: "maven-plugin"
+        update-types: ["version-update:semver-minor"]

--- a/pom.xml
+++ b/pom.xml
@@ -51,10 +51,10 @@
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>maven-plugin</artifactId>
-        <!-- Intentionally kept at 3.22 to not disrupt Jenkins plugin bill of materials -->
+        <!-- Intentionally kept at 3.16 to not disrupt Jenkins plugin bill of materials -->
         <!-- https://github.com/jenkinsci/bom/pull/1978#issuecomment-1516220549 -->
         <!-- TODO: Before upgrading this version, must check that plugin bill of materials is unharmed -->
-        <version>3.22</version>
+        <version>3.16</version>
         <optional>true</optional>
       </dependency>
       <dependency>


### PR DESCRIPTION
## Revert maven plugin upgrade

- Revert "Bump maven-plugin from 3.16 to 3.22 (#184)"
- Exclude maven plugin from dependabot updates

### Testing done

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore
reviewed in hopes of getting the correct syntax to disable updates of
the maven plugin.

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
