### PR TITLE
Fixed NPE when setting selector explicitly to null from groovy

### DIFF
--- a/src/main/java/hudson/plugins/copyartifact/CopyArtifact.java
+++ b/src/main/java/hudson/plugins/copyartifact/CopyArtifact.java
@@ -161,9 +161,6 @@ public class CopyArtifact extends Builder implements SimpleBuildStep {
         setFilter(filter);
         setTarget(target);
         setExcludes(excludes);
-        if (selector == null) {
-            selector = DEFAULT_BUILD_SELECTOR;
-        }
         setSelector(selector);
         setFlatten(flatten);
         setOptional(optional);
@@ -227,6 +224,9 @@ public class CopyArtifact extends Builder implements SimpleBuildStep {
 
     @DataBoundSetter
     public void setSelector(@NonNull BuildSelector selector) {
+        if (selector == null) {
+            selector = DEFAULT_BUILD_SELECTOR;
+        }
         this.selector = selector;
     }
 

--- a/src/test/java/hudson/plugins/copyartifact/LastStableBuildSelectorTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/LastStableBuildSelectorTest.java
@@ -1,0 +1,44 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019, Chad Gilman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.copyartifact;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class LastStableBuildSelectorTest {
+
+    @Rule
+    public final JenkinsRule rule = new JenkinsRule();
+
+    @Test
+    public void testNullSettingSelectorNullFallsBackToDefaultAkaStableSelector() throws Exception {
+        CopyArtifact copyArtifact = new CopyArtifact("dummy");
+        copyArtifact.setSelector(null);
+        BuildSelector s = copyArtifact.getSelector();
+        org.junit.Assert.assertNotNull(s);
+        org.junit.Assert.assertTrue(s instanceof StatusBuildSelector);
+        org.junit.Assert.assertTrue(((StatusBuildSelector)s).isStable());
+    }
+}


### PR DESCRIPTION
When doing  e.g.
```
def selector = someCondition ? specific(BUILD)) : null;
copyArtifacts(fingerprintArtifacts: true, selector: selector, projectName: "someProject")
```

leads to: 
```
Also:   org.jenkinsci.plugins.workflow.actions.ErrorAction$ErrorId: xyz
java.lang.NullPointerException
	at hudson.plugins.copyartifact.CopyArtifact.perform(CopyArtifact.java:482)
	at jenkins.tasks.SimpleBuildStep.perform(SimpleBuildStep.java:123)
	at org.jenkinsci.plugins.workflow.steps.CoreStep$Execution.run(CoreStep.java:101)
	at org.jenkinsci.plugins.workflow.steps.CoreStep$Execution.run(CoreStep.java:71)
	at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution.lambda$start$0(SynchronousNonBlockingStepExecution.java:47)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
```

though I would expect to get the default (aka. stable) artifact selector.

### Testing done

No, please add a dedicated unit test

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x]  Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
