### PR TITLE
Require Jenkins 2.387.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <revision>1.49</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-        <jenkins.version>2.361.4</jenkins.version>
+        <jenkins.version>2.387.3</jenkins.version>
         <useBeta>true</useBeta>
         <spotbugs.effort>Max</spotbugs.effort>
         <spotbugs.threshold>Low</spotbugs.threshold>
@@ -51,10 +51,6 @@
       <dependency>
         <groupId>org.jenkins-ci.main</groupId>
         <artifactId>maven-plugin</artifactId>
-        <!-- Intentionally kept at 3.16 to not disrupt Jenkins plugin bill of materials -->
-        <!-- https://github.com/jenkinsci/bom/pull/1978#issuecomment-1516220549 -->
-        <!-- TODO: Before upgrading this version, must check that plugin bill of materials is unharmed -->
-        <version>3.16</version>
         <optional>true</optional>
       </dependency>
       <dependency>
@@ -151,8 +147,8 @@
       <dependencies>
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
-          <artifactId>bom-2.361.x</artifactId>
-          <version>2102.v854b_fec19c92</version>
+          <artifactId>bom-2.387.x</artifactId>
+          <version>2329.v078520e55c19</version>
           <scope>import</scope>
           <type>pom</type>
         </dependency>


### PR DESCRIPTION
## Require Jenkins 2.387.3 or newer

Simplify dependency tracking in the pom file by using the maven plugin version from the plugin bill of materials instead of relying on testing of each proposed increment of the maven plugin version.  

### Testing done

Confirmed that automated tests are passing.  Since the maven plugin is now included in the bom, this change has already been checked for compatibility with bom.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
