### PR TITLE
Test with Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,9 +8,10 @@ buildPlugin(
   useContainerAgent: true,
   // Show failures on all configurations
   failFast: false,
-  // Test Java 11 and Java 17
+  // Test Java 11, 17, and 21
   configurations: [
     [platform: 'linux',   jdk: '17'], // Linux first for coverage report on ci.jenkins.io
+    [platform: 'linux',   jdk: '21', jenkins: '2.414'],
     [platform: 'windows', jdk: '11'],
   ]
 )


### PR DESCRIPTION
## Test with Java 21

Java 21 will release Sep 19, 2023.  We'd like to support it with Jenkins core and Jenkins plugins shortly after release.

### Testing done

Confirmed that automated tests pass with Java 21.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
