### PR TITLE
Update readme to highlight interaction between "Authenticated" user group and Permission checking

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -132,6 +132,8 @@ You can configure to allow Copy Artifact to access source jobs in the following 
 * <<CopyArtifactPlugin-Specifyprojectswhocancopyartifacts,Configure source jobs specifying jobs who can copy artifacts.>>
 * <<CopyArtifactPlugin-Authorizebuildsasauser,Authorize builds as a user.>>
 
+This message will not be encountered if the "Authenticated" user group has the "job/read" permission enabled. If you are suddenly starting to run into this issue, it is worth checking to see if this configuration has recently changed.
+
 [[CopyArtifactPlugin-Specifyprojectswhocancopyartifacts]]
 ==== Specify projects who can copy artifacts
 

--- a/README.adoc
+++ b/README.adoc
@@ -132,7 +132,7 @@ You can configure to allow Copy Artifact to access source jobs in the following 
 * <<CopyArtifactPlugin-Specifyprojectswhocancopyartifacts,Configure source jobs specifying jobs who can copy artifacts.>>
 * <<CopyArtifactPlugin-Authorizebuildsasauser,Authorize builds as a user.>>
 
-This message will not be encountered if the "Authenticated" user group has the "job/read" permission enabled. If you are suddenly starting to run into this issue, it is worth checking to see if this configuration has recently changed.
+It is also worth noting that message will not be encountered if the "Authenticated" user group has the "job/read" permission enabled. If you are suddenly starting to run into this issue, it is worth checking to see if this configuration has recently changed.
 
 [[CopyArtifactPlugin-Specifyprojectswhocancopyartifacts]]
 ==== Specify projects who can copy artifacts

--- a/README.adoc
+++ b/README.adoc
@@ -132,7 +132,8 @@ You can configure to allow Copy Artifact to access source jobs in the following 
 * <<CopyArtifactPlugin-Specifyprojectswhocancopyartifacts,Configure source jobs specifying jobs who can copy artifacts.>>
 * <<CopyArtifactPlugin-Authorizebuildsasauser,Authorize builds as a user.>>
 
-It is also worth noting that message will not be encountered if the "Authenticated" user group has the "job/read" permission enabled. If you are suddenly starting to run into this issue, it is worth checking to see if this configuration has recently changed.
+The message will not be encountered if the "Authenticated" user group has the "job/read" permission enabled.
+If this issue appears on your controller, check if this configuration has recently changed.
 
 [[CopyArtifactPlugin-Specifyprojectswhocancopyartifacts]]
 ==== Specify projects who can copy artifacts


### PR DESCRIPTION
This pull request adds a minor update to the readme.

The reason I am adding this, is that recently we ran into a issue where we were suddenly seeing the 

```
Unable to find project for artifact copy: YOUR_PROJECT_WITH_ARTIFACTS
This may be due to incorrect project name or permission settings; see help for project name in job configuration.
Build step 'Copy artifacts from another project' marked build as failure

```
message after a Jenkins Update and couldn't figure out why.  It was only after looking at the source code (in particular [here](https://github.com/jenkinsci/copyartifact-plugin/blob/master/src/main/java/hudson/plugins/copyartifact/CopyArtifact.java#L594-L601)) that I was able to determine the issue.

This PR is a suggestion to include this additional line in the readme, as I don't believe that one should need to look into the source code to determine such a behavior.


### Testing done

Ensured the readme looks "good" on the github page.  This PR contains no actual code change

```[tasklist]
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
