### PR TITLE
Use Jenkinsfile from plugin archetype

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,17 +1,11 @@
-// Specify configurations explicitly to test against newer LTS.
-// See also https://github.com/jenkins-infra/pipeline-library/pull/145
-
+/*
+ See the documentation for more options:
+ https://github.com/jenkins-infra/pipeline-library/
+*/
 buildPlugin(
-  // Run a JVM per core in tests
-  forkCount: '1C',
-  // Container agents start faster and are easier to administer
-  useContainerAgent: true,
-  // Show failures on all configurations
-  failFast: false,
-  // Test Java 11, 17, and 21
+  forkCount: '1C', // Run a JVM per core in tests
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
-    [platform: 'linux',   jdk: '17'], // Linux first for coverage report on ci.jenkins.io
-    [platform: 'linux',   jdk: '21', jenkins: '2.414'],
-    [platform: 'windows', jdk: '11'],
-  ]
-)
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
+])


### PR DESCRIPTION
## Use Jenkinsfile from plugin archetype

Use the Jenkinsfile from the plugin archetype in order to reduce differences throughout the Jenkins organization.

The Jenkinsfile from the plugin archetype is extended to run tests in parallel in order to reduce the time and cost of tests.

https://github.com/jenkinsci/archetypes/issues/650 describes the alternatives for Jenkinsfile configurations.

### Testing done

No additional tests needed.  Pull request will be verified by ci.jenkins.io .

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
