### PR TITLE
Simplify JSON parsing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <revision>1.49</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-        <jenkins.version>2.414.3</jenkins.version>
+        <jenkins.version>2.426.3</jenkins.version>
         <useBeta>true</useBeta>
         <spotbugs.effort>Max</spotbugs.effort>
         <spotbugs.threshold>Low</spotbugs.threshold>
@@ -162,7 +162,7 @@
       <dependencies>
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
-          <artifactId>bom-2.414.x</artifactId>
+          <artifactId>bom-2.426.x</artifactId>
           <version>2982.vdce2153031a_0</version>
           <scope>import</scope>
           <type>pom</type>

--- a/src/main/resources/hudson/plugins/copyartifact/monitor/LegacyJobConfigMigrationMonitor/resources.js
+++ b/src/main/resources/hudson/plugins/copyartifact/monitor/LegacyJobConfigMigrationMonitor/resources.js
@@ -109,8 +109,7 @@ function confirmAndSendRequest(button){
                 headers: crumb.wrap({
                     'Content-Type': 'application/json; charset=UTF-8',
                 }),
-                // TODO simplify when Prototype.js is removed
-                body: Object.toJSON ? Object.toJSON(params) : JSON.stringify(params),
+                body: JSON.stringify(params),
             }).then((rsp) => {
                 window.location.reload();
             });


### PR DESCRIPTION
Now that Prototype.js has been removed in 2.426.x, we can remove the no-longer needed `Object.toJSON` workaround.

### Testing done

`mvn clean verify -DskipTests`