### PR TITLE
Stop handling `PosixException` that is no longer thrown

### DIFF
--- a/src/main/java/hudson/plugins/copyartifact/FingerprintingCopyMethod.java
+++ b/src/main/java/hudson/plugins/copyartifact/FingerprintingCopyMethod.java
@@ -8,7 +8,6 @@ import hudson.model.Fingerprint;
 import hudson.model.FingerprintMap;
 import hudson.model.Run;
 import hudson.model.TaskListener;
-import hudson.os.PosixException;
 import hudson.tasks.Fingerprinter.FingerprintAction;
 import jenkins.model.Jenkins;
 
@@ -89,9 +88,7 @@ public class FingerprintingCopyMethod extends Copier {
             }
             try {
                 d.chmod(s.mode());
-            } catch (IOException | PosixException x) {
-                // PosixException for Jenkins < 2.339
-                // IOException for Jenkins >= 2.339
+            } catch (IOException x) {
                 LOGGER.log(Level.WARNING, "could not check mode of " + s, x);
             }
             // FilePath.setLastModifiedIfPossible private; copyToWithPermission OK but would have to calc digest separately:


### PR DESCRIPTION
Stop handling not used and deprecated `PosixException` which was thrown before Jenkins 2.339. But the pom has today a minimum Jenkins version of [2.426.3](https://github.com/jenkinsci/copyartifact-plugin/blob/master/pom.xml#L31).
With a few other PRs we might be able to remove the `PosixException` from core.

### Testing done

Ran tests locally

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
