### PR TITLE
Require Jenkins 2.452.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
         <revision>1.49</revision>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-        <jenkins.baseline>2.426</jenkins.baseline>
-        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+        <jenkins.baseline>2.452</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.4</jenkins.version>
         <useBeta>true</useBeta>
         <spotbugs.effort>Max</spotbugs.effort>
         <spotbugs.threshold>Low</spotbugs.threshold>
@@ -164,7 +164,7 @@
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
           <artifactId>bom-${jenkins.baseline}.x</artifactId>
-          <version>3208.vb_21177d4b_cd9</version>
+          <version>3790.va_b_a_2d26d2b_69</version>
           <scope>import</scope>
           <type>pom</type>
         </dependency>

--- a/src/test/java/hudson/plugins/copyartifact/testutils/CopyArtifactJenkinsRule.java
+++ b/src/test/java/hudson/plugins/copyartifact/testutils/CopyArtifactJenkinsRule.java
@@ -96,7 +96,7 @@ public class CopyArtifactJenkinsRule extends JenkinsRule {
      * @return the new workflow job
      * @throws IOException an error when creating a new job
      */
-    public WorkflowJob createWorkflow(String name, String script) throws IOException {
+    public WorkflowJob createWorkflow(String name, String script) throws Exception {
         WorkflowJob job = jenkins.createProject(WorkflowJob.class, name);
         job.setDefinition(new CpsFlowDefinition("node {" + script + "}", true));
         return job;


### PR DESCRIPTION
Require Jenkins 2.452.4

Over 80% of [installations of the last two releases](https://stats.jenkins.io/pluginversions/copyartifact.html) are already on Jenkins 2.452.4 or newer.

### Testing done

Automated tests only

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
