### PR TITLE
Revert 'Bump org.jenkins-ci.plugins:plugin from 5.7 to 5.9'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>5.9</version>
+        <version>5.7</version>
         <relativePath />
     </parent>
 

--- a/src/main/java/hudson/plugins/copyartifact/FilePathCopyMethod.java
+++ b/src/main/java/hudson/plugins/copyartifact/FilePathCopyMethod.java
@@ -29,6 +29,8 @@ import hudson.model.Run;
 
 import java.io.IOException;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Default implementation of CopyMethod extension point,
  * using the Jenkins FilePath class.  Has -100 ordinal value so any other
@@ -53,6 +55,10 @@ public class FilePathCopyMethod extends Copier {
         source.copyToWithPermission(target);
     }
 
+    @SuppressFBWarnings(
+            value = "CN_IMPLEMENTS_CLONE_BUT_NOT_CLONEABLE",
+            justification = "This is a method not of Cloneable but of Copier."
+    )
     @Override
     public Copier clone() {
         return this;

--- a/src/main/java/hudson/plugins/copyartifact/FingerprintingCopyMethod.java
+++ b/src/main/java/hudson/plugins/copyartifact/FingerprintingCopyMethod.java
@@ -20,6 +20,8 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Performs fingerprinting during the copy.
  *
@@ -137,6 +139,10 @@ public class FingerprintingCopyMethod extends Copier {
         }
     }
 
+    @SuppressFBWarnings(
+            value = "CN_IMPLEMENTS_CLONE_BUT_NOT_CLONEABLE",
+            justification = "This is a method not of Cloneable but of Copier."
+    )
     @Override
     public Copier clone() {
         return new FingerprintingCopyMethod();

--- a/src/spotbugs/excludesFilter.xml
+++ b/src/spotbugs/excludesFilter.xml
@@ -38,14 +38,6 @@
       <Class name="hudson.plugins.copyartifact.WorkspaceSelector$DescriptorImpl"/>
     </Or>
   </Match>
-  <Match>
-    <!-- clone methods are inherited from Copier, not from Cloneable -->
-    <Bug pattern="CN_IMPLEMENTS_CLONE_BUT_NOT_CLONEABLE"/>
-    <Or>
-      <Class name="hudson.plugins.copyartifact.FingerprintingCopyMethod"/>
-      <Class name="hudson.plugins.copyartifact.FilePathCopyMethod"/>
-    </Or>
-  </Match>
 
   <!--
     Here lies technical debt. Exclusions in this section have not yet


### PR DESCRIPTION
## Revert "Bump org.jenkins-ci.plugins:plugin from 5.7 to 5.9"

Tests are failing since this upgrade.  The tests that failed in the last 4 jobs are:

* windows-17 / TriggeredBuildSelectorTest.testTryUpstreamBuildEnabled (2)
* windows-17 / TriggeredBuildSelectorTest.testTryUpstreamBuildDisabled (3)

This change will allow multiple tests to see the failure rate without the change.

This reverts commit 82c331377431f8af93521cf22f93cea5bb781c8b.

### Testing done

Tests do not fail on my local Linux computer or on the Linux agent of ci.jenkins.io.  Will test on my local Windows computers after this pull request is submitted.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
