### PR TITLE
Skip CopyArtifactTest#testSymlinks tests on Windows if no symlink support

### DIFF
--- a/src/test/java/hudson/plugins/copyartifact/CopyArtifactTest.java
+++ b/src/test/java/hudson/plugins/copyartifact/CopyArtifactTest.java
@@ -130,6 +130,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeThat;
 
 /**
@@ -1920,6 +1921,11 @@ public class CopyArtifactTest {
         FreeStyleBuild b = rule.buildAndAssertSuccess(p2);
         FilePath ws = b.getWorkspace();
         assertEquals("text", ws.child("plain").readToString());
+        // Windows 10 and 11 by default will not create symbolic links. Don't fail test
+        // Mark the test as skipped if running on Windows and both symlinks return null
+        assumeFalse(Functions.isWindows() &&
+                    ws.child("link1").readLink() == null &&
+                    ws.child("link2").readLink() == null);
         assertEquals("plain", ws.child("link1").readLink());
         assertEquals("nonexistent", ws.child("link2").readLink());
     }
@@ -1943,6 +1949,10 @@ public class CopyArtifactTest {
         FreeStyleBuild b = rule.buildAndAssertSuccess(p2);
         FilePath ws = b.getWorkspace();
         assertEquals("text", ws.child("plain").readToString());
+        // Windows 10 and 11 by default will not create symbolic links. Don't fail test
+        // Mark the test as skipped if running on Windows and symlink is null
+        assumeFalse(Functions.isWindows() &&
+                    ws.child("dir/link1").readLink() == null);
         assertEquals(
             StringUtils.join(
                 new String[]{"..", "plain"},


### PR DESCRIPTION
## Skip CopyArtifactTest#testSymlinks tests on Windows if no symlink support

Windows 10 and Windows 11 do not allow symbolic links to be created unless the permission is granted to the user in group policy and the Windows developer mode is enabled.

https://gist.github.com/huenisys/1efb64e57c37cfab7054c65702588fce provides one description.

https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-10/security/threat-protection/security-policy-settings/create-symbolic-links warns that it is a security risk to allow symbolic links in applications that are not designed to handle them.

### Testing done

Confirmed that tests are skipped as expected when on a Windows computer without symlink support.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
